### PR TITLE
feat(todo): UX improvements for Todo board and edit panel

### DIFF
--- a/src/components/TodoBoard.jsx
+++ b/src/components/TodoBoard.jsx
@@ -1,5 +1,5 @@
 import { useState, useMemo, useEffect, useCallback } from 'react';
-import { Plus, EyeOff, Eye, Filter, X, GripVertical, Play, Flag, ArrowUpDown } from 'lucide-react';
+import { Plus, EyeOff, Eye, Filter, X, GripVertical, Play, Flag, ArrowUpDown, PanelRight, Square } from 'lucide-react';
 import TodoCard from './TodoCard';
 import TodoFormModal from './TodoFormModal';
 
@@ -24,6 +24,15 @@ export default function TodoBoard({
 
   // Sort: null | 'priority-desc' | 'priority-asc' | 'dueDate-asc' | 'dueDate-desc'
   const [sortBy, setSortBy] = useState('dueDate-asc');
+
+  // Edit panel variant: 'drawer' (default) | 'modal', persisted in localStorage
+  const [editVariant, setEditVariant] = useState(() => {
+    const saved = typeof window !== 'undefined' ? localStorage.getItem('todoEditVariant') : null;
+    return saved === 'modal' || saved === 'drawer' ? saved : 'drawer';
+  });
+  useEffect(() => {
+    localStorage.setItem('todoEditVariant', editVariant);
+  }, [editVariant]);
 
   const toggleFilter = (setter, value) => {
     setter(prev => {
@@ -269,13 +278,23 @@ export default function TodoBoard({
             到期日{sortBy === 'dueDate-asc' ? ' ↑' : sortBy === 'dueDate-desc' ? ' ↓' : ''}
           </button>
         </div>
-        <button
-          onClick={() => setHideDone(h => !h)}
-          className="flex items-center gap-1 text-sm text-gray-500 hover:text-gray-700"
-        >
-          {hideDone ? <Eye size={14} /> : <EyeOff size={14} />}
-          {hideDone ? `顯示${endStatusName}` : `隱藏${endStatusName}`}
-        </button>
+        <div className="flex items-center gap-3">
+          <button
+            onClick={() => setEditVariant(v => v === 'drawer' ? 'modal' : 'drawer')}
+            className="flex items-center gap-1 text-sm text-gray-500 hover:text-gray-700"
+            title={editVariant === 'drawer' ? '切換為置中視窗' : '切換為右側面板'}
+          >
+            {editVariant === 'drawer' ? <PanelRight size={14} /> : <Square size={14} />}
+            {editVariant === 'drawer' ? '右側面板' : '置中視窗'}
+          </button>
+          <button
+            onClick={() => setHideDone(h => !h)}
+            className="flex items-center gap-1 text-sm text-gray-500 hover:text-gray-700"
+          >
+            {hideDone ? <Eye size={14} /> : <EyeOff size={14} />}
+            {hideDone ? `顯示${endStatusName}` : `隱藏${endStatusName}`}
+          </button>
+        </div>
       </div>
 
       {/* Filter bar */}
@@ -453,6 +472,7 @@ export default function TodoBoard({
           onCreateComment={onCreateComment}
           onUpdateComment={onUpdateComment}
           onDeleteComment={onDeleteComment}
+          variant={editVariant}
         />
       )}
     </div>

--- a/src/components/TodoBoard.jsx
+++ b/src/components/TodoBoard.jsx
@@ -23,7 +23,7 @@ export default function TodoBoard({
   const [showFilters, setShowFilters] = useState(false);
 
   // Sort: null | 'priority-desc' | 'priority-asc' | 'dueDate-asc' | 'dueDate-desc'
-  const [sortBy, setSortBy] = useState(null);
+  const [sortBy, setSortBy] = useState('dueDate-asc');
 
   const toggleFilter = (setter, value) => {
     setter(prev => {

--- a/src/components/TodoCard.jsx
+++ b/src/components/TodoCard.jsx
@@ -9,6 +9,29 @@ const PRIORITY_STYLES = {
 
 const PRIORITY_LABELS = { high: '高', medium: '中', low: '低' };
 
+const ASSIGNEE_COLORS = [
+  'bg-rose-400',
+  'bg-orange-400',
+  'bg-amber-400',
+  'bg-lime-500',
+  'bg-emerald-500',
+  'bg-teal-500',
+  'bg-cyan-500',
+  'bg-sky-500',
+  'bg-indigo-400',
+  'bg-violet-500',
+  'bg-fuchsia-500',
+  'bg-pink-500',
+];
+
+function assigneeColor(name) {
+  let hash = 0;
+  for (let i = 0; i < name.length; i++) {
+    hash = (hash * 31 + name.charCodeAt(i)) | 0;
+  }
+  return ASSIGNEE_COLORS[Math.abs(hash) % ASSIGNEE_COLORS.length];
+}
+
 export default function TodoCard({ todo, isDone, onEdit, onDragStart, onDragEnd, allTasks }) {
   const ps = PRIORITY_STYLES[todo.priority] || PRIORITY_STYLES.medium;
 
@@ -58,7 +81,7 @@ export default function TodoCard({ todo, isDone, onEdit, onDragStart, onDragEnd,
         <div className="flex items-center gap-1">
           {todo.assignee && (
             <>
-              <div className="w-5 h-5 rounded-full bg-indigo-400 text-white flex items-center justify-center text-[10px] font-bold">
+              <div className={`w-5 h-5 rounded-full ${assigneeColor(todo.assignee)} text-white flex items-center justify-center text-[10px] font-bold`}>
                 {todo.assignee.charAt(0).toUpperCase()}
               </div>
               <span>{todo.assignee}</span>

--- a/src/components/TodoCard.jsx
+++ b/src/components/TodoCard.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Calendar } from 'lucide-react';
+import { Calendar, MessageSquare } from 'lucide-react';
 
 const PRIORITY_STYLES = {
   high: { border: 'border-l-red-500', badge: 'bg-red-50 text-red-600' },
@@ -88,6 +88,12 @@ export default function TodoCard({ todo, isDone, onEdit, onDragStart, onDragEnd,
             </>
           )}
         </div>
+        {todo.comments && todo.comments.length > 0 && (
+          <span className="flex items-center gap-0.5" title={`${todo.comments.length} 則留言`}>
+            <MessageSquare size={11} />
+            {todo.comments.length}
+          </span>
+        )}
         {todo.dueDate && (
           <span className={`flex items-center gap-0.5 ${isOverdue ? 'text-red-500 font-semibold' : ''}`}>
             <Calendar size={11} />

--- a/src/components/TodoFormModal.jsx
+++ b/src/components/TodoFormModal.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo } from 'react';
+import React, { useState, useMemo, useEffect } from 'react';
 import { X, Trash2, Send, Pencil } from 'lucide-react';
 
 const URL_REGEX = /(https?:\/\/[^\s]+)/g;
@@ -24,7 +24,8 @@ function renderCommentContent(text) {
   });
 }
 
-export default function TodoFormModal({ todo, statuses, allTasks: _allTasks, projects, allTags, allAssignees, onSave, onDelete, onClose, onCreateComment, onUpdateComment, onDeleteComment }) {
+export default function TodoFormModal({ todo, statuses, allTasks: _allTasks, projects, allTags, allAssignees, onSave, onDelete, onClose, onCreateComment, onUpdateComment, onDeleteComment, variant = 'modal' }) {
+  const isDrawer = variant === 'drawer';
   const isEdit = !!todo;
   const startStatus = statuses.find(s => s.isDefaultStart);
 
@@ -41,6 +42,19 @@ export default function TodoFormModal({ todo, statuses, allTasks: _allTasks, pro
   }), [todo, startStatus]);
 
   const [form, setForm] = useState(initialForm);
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    if (!isDrawer) return;
+    const id = requestAnimationFrame(() => setMounted(true));
+    return () => cancelAnimationFrame(id);
+  }, [isDrawer]);
+
+  useEffect(() => {
+    const onKey = (e) => { if (e.key === 'Escape') onClose(); };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [onClose]);
 
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const [commentInput, setCommentInput] = useState('');
@@ -111,16 +125,24 @@ export default function TodoFormModal({ todo, statuses, allTasks: _allTasks, pro
   }, [allTags, form.tags]);
 
   return (
-    <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-[80] p-4" onClick={onClose}>
-      <div className="bg-white rounded-xl shadow-2xl w-full max-w-md overflow-hidden" onClick={e => e.stopPropagation()}>
-        <div className="flex justify-between items-center p-4 border-b border-gray-100">
+    <div className={`fixed inset-0 bg-black/40 z-[80] ${isDrawer ? '' : 'flex items-center justify-center p-4'}`} onClick={onClose}>
+      <div
+        className={
+          isDrawer
+            ? `fixed right-0 top-0 h-full w-[480px] max-w-full bg-white shadow-2xl flex flex-col transform transition-transform duration-300 ease-out ${mounted ? 'translate-x-0' : 'translate-x-full'}`
+            : 'bg-white rounded-xl shadow-2xl w-full max-w-md overflow-hidden'
+        }
+        onClick={e => e.stopPropagation()}
+      >
+        <div className={`flex justify-between items-center p-4 border-b border-gray-100 ${isDrawer ? 'shrink-0' : ''}`}>
           <h3 className="text-base font-bold text-gray-800">{isEdit ? '編輯 Todo' : '新增 Todo'}</h3>
           <button onClick={onClose} className="p-1 rounded-full hover:bg-gray-100 text-gray-400 hover:text-gray-600">
             <X size={20} />
           </button>
         </div>
 
-        <form onSubmit={handleSubmit} className="p-4 space-y-3">
+        <form onSubmit={handleSubmit} className={isDrawer ? 'flex-1 flex flex-col min-h-0' : ''}>
+          <div className={isDrawer ? 'flex-1 overflow-y-auto p-4 space-y-3' : 'p-4 space-y-3'}>
           {/* Title */}
           <div>
             <label className="text-xs font-medium text-gray-600 block mb-1">標題 *</label>
@@ -272,7 +294,7 @@ export default function TodoFormModal({ todo, statuses, allTasks: _allTasks, pro
                             <textarea
                               value={editingCommentContent}
                               onChange={e => setEditingCommentContent(e.target.value)}
-                              onKeyDown={e => { if (e.key === 'Escape') setEditingCommentId(null); }}
+                              onKeyDown={e => { if (e.key === 'Escape') { e.stopPropagation(); setEditingCommentId(null); } }}
                               className="w-full border border-indigo-300 rounded px-2 py-1 text-sm outline-none resize-none"
                               rows={2}
                               autoFocus
@@ -326,8 +348,13 @@ export default function TodoFormModal({ todo, statuses, allTasks: _allTasks, pro
             </div>
           )}
 
+          </div>
+
           {/* Buttons */}
-          <div className="flex justify-between items-center pt-2">
+          <div className={isDrawer
+            ? 'border-t border-gray-100 p-3 flex justify-between items-center shrink-0 bg-white'
+            : 'flex justify-between items-center px-4 pb-4 pt-2'
+          }>
             {isEdit && !showDeleteConfirm && (
               <button
                 type="button"

--- a/src/components/TodoFormModal.jsx
+++ b/src/components/TodoFormModal.jsx
@@ -1,6 +1,29 @@
 import React, { useState, useMemo } from 'react';
 import { X, Trash2, Send, Pencil } from 'lucide-react';
 
+const URL_REGEX = /(https?:\/\/[^\s]+)/g;
+
+function renderCommentContent(text) {
+  const parts = text.split(URL_REGEX);
+  return parts.map((part, i) => {
+    if (i % 2 === 1) {
+      return (
+        <a
+          key={i}
+          href={part}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-indigo-600 hover:underline break-all"
+          onClick={(e) => e.stopPropagation()}
+        >
+          {part}
+        </a>
+      );
+    }
+    return <React.Fragment key={i}>{part}</React.Fragment>;
+  });
+}
+
 export default function TodoFormModal({ todo, statuses, allTasks: _allTasks, projects, allTags, allAssignees, onSave, onDelete, onClose, onCreateComment, onUpdateComment, onDeleteComment }) {
   const isEdit = !!todo;
   const startStatus = statuses.find(s => s.isDefaultStart);
@@ -263,7 +286,7 @@ export default function TodoFormModal({ todo, statuses, allTasks: _allTasks, pro
                         ) : (
                           <div className="flex items-start justify-between">
                             <div>
-                              <p className="text-gray-700">{c.content}</p>
+                              <p className="text-gray-700 whitespace-pre-wrap break-words">{renderCommentContent(c.content)}</p>
                               <span className="text-[10px] text-gray-400">
                                 {new Date(c.createdAt).toLocaleString('zh-TW')}
                                 {c.updatedAt !== c.createdAt && ' (已編輯)'}


### PR DESCRIPTION
## Summary

- Assignee avatar colored by name hash for visual distinction across cards
- Default sort by due date (ascending) when entering the Todo board
- Comment count badge on Todo cards
- URLs in comment content rendered as clickable links
- New right-side drawer variant for the edit panel with a toolbar toggle to switch between drawer and centered modal (persisted in localStorage)

## Test plan

- [ ] Open Todo board: cards with assignees show distinct colors per user
- [ ] Board defaults to sorting by due date ascending on first load
- [ ] Cards with comments show a comment-count badge
- [ ] Comments containing http(s) URLs render as clickable links (open in new tab)
- [ ] Toolbar toggle switches between drawer and modal; preference persists after reload
- [ ] Drawer: slides in from right, backdrop click + ESC close, body scrolls, footer sticky
- [ ] Modal: visual parity with previous behavior
- [ ] ESC inside comment edit textarea only cancels comment edit, does not close panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)