### PR TITLE
feat: sub-projects with waiting tracking and todo integration

### DIFF
--- a/backend/db.py
+++ b/backend/db.py
@@ -109,6 +109,46 @@ def init_db() -> None:
                 FOREIGN KEY (todo_id) REFERENCES todos(id) ON DELETE CASCADE,
                 FOREIGN KEY (author_id) REFERENCES users(id) ON DELETE SET NULL
             );
+            CREATE TABLE IF NOT EXISTS sub_projects (
+                id TEXT PRIMARY KEY,
+                burnup_project_id TEXT NOT NULL,
+                name TEXT NOT NULL,
+                description TEXT,
+                status TEXT NOT NULL DEFAULT 'active',
+                owner TEXT,
+                due_date TEXT,
+                priority TEXT NOT NULL DEFAULT 'medium',
+                tags TEXT NOT NULL DEFAULT '[]',
+                sort_order REAL NOT NULL DEFAULT 0,
+                created_at TEXT NOT NULL,
+                created_by TEXT,
+                FOREIGN KEY (burnup_project_id) REFERENCES projects(id) ON DELETE CASCADE,
+                FOREIGN KEY (created_by) REFERENCES users(id) ON DELETE SET NULL
+            );
+            CREATE INDEX IF NOT EXISTS idx_sub_projects_burnup ON sub_projects(burnup_project_id);
+            CREATE TABLE IF NOT EXISTS sub_project_tasks (
+                sub_project_id TEXT NOT NULL,
+                task_id TEXT NOT NULL,
+                PRIMARY KEY (sub_project_id, task_id),
+                FOREIGN KEY (sub_project_id) REFERENCES sub_projects(id) ON DELETE CASCADE,
+                FOREIGN KEY (task_id) REFERENCES tasks(id) ON DELETE CASCADE
+            );
+            CREATE TABLE IF NOT EXISTS sub_project_events (
+                id TEXT PRIMARY KEY,
+                parent_type TEXT NOT NULL CHECK (parent_type IN ('sub_project', 'todo')),
+                parent_id TEXT NOT NULL,
+                type TEXT NOT NULL CHECK (type IN ('waiting', 'note', 'decision')),
+                title TEXT NOT NULL,
+                body TEXT,
+                waiting_on TEXT,
+                started_at TEXT NOT NULL,
+                resolved_at TEXT,
+                created_at TEXT NOT NULL,
+                created_by TEXT,
+                FOREIGN KEY (created_by) REFERENCES users(id) ON DELETE SET NULL
+            );
+            CREATE INDEX IF NOT EXISTS idx_sub_project_events_parent ON sub_project_events(parent_type, parent_id);
+            CREATE INDEX IF NOT EXISTS idx_sub_project_events_active ON sub_project_events(type, resolved_at);
             """
         )
         # Seed default statuses if table is empty
@@ -161,3 +201,7 @@ def init_db() -> None:
         }
         if "author_id" not in log_columns:
             conn.execute("ALTER TABLE logs ADD COLUMN author_id TEXT")
+
+        # Add sub_project_id to todos if missing
+        if "sub_project_id" not in todo_columns:
+            conn.execute("ALTER TABLE todos ADD COLUMN sub_project_id TEXT")

--- a/backend/main.py
+++ b/backend/main.py
@@ -6,7 +6,7 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from auth import cleanup_expired_tokens
 from db import init_db
-from routers import auth_routes, logs, projects, statuses, tasks, todos
+from routers import auth_routes, logs, projects, statuses, sub_projects, tasks, todos
 
 app = FastAPI(title="Burnup Chart API")
 
@@ -32,6 +32,7 @@ app.include_router(tasks.router)
 app.include_router(logs.router)
 app.include_router(statuses.router)
 app.include_router(todos.router)
+app.include_router(sub_projects.router)
 
 
 @app.on_event("startup")

--- a/backend/models.py
+++ b/backend/models.py
@@ -144,6 +144,7 @@ class TodoCreate(BaseModel):
     tags: List[str] = Field(default_factory=list)
     note: Optional[str] = None
     linkedTaskId: Optional[str] = None
+    subProjectId: Optional[str] = None
 
 
 class TodoUpdate(BaseModel):
@@ -155,6 +156,7 @@ class TodoUpdate(BaseModel):
     tags: Optional[List[str]] = None
     note: Optional[str] = None
     linkedTaskId: Optional[str] = None
+    subProjectId: Optional[str] = None
     sortOrder: Optional[float] = None
 
 
@@ -184,9 +186,82 @@ class TodoOut(BaseModel):
     tags: List[str] = Field(default_factory=list)
     note: Optional[str] = None
     linkedTaskId: Optional[str] = None
+    subProjectId: Optional[str] = None
     createdAt: str
     sortOrder: float
     comments: List[TodoCommentOut] = Field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Sub-project models
+# ---------------------------------------------------------------------------
+
+
+class SubProjectCreate(BaseModel):
+    id: Optional[str] = None
+    name: str
+    description: Optional[str] = None
+    status: str = "active"
+    owner: Optional[str] = None
+    dueDate: Optional[str] = None
+    priority: str = "medium"
+    tags: List[str] = Field(default_factory=list)
+    linkedTaskIds: List[str] = Field(default_factory=list)
+
+
+class SubProjectUpdate(BaseModel):
+    name: Optional[str] = None
+    description: Optional[str] = None
+    status: Optional[str] = None
+    owner: Optional[str] = None
+    dueDate: Optional[str] = None
+    priority: Optional[str] = None
+    tags: Optional[List[str]] = None
+    linkedTaskIds: Optional[List[str]] = None
+    sortOrder: Optional[float] = None
+
+
+class SubProjectOut(BaseModel):
+    id: str
+    burnupProjectId: str
+    name: str
+    description: Optional[str] = None
+    status: str
+    owner: Optional[str] = None
+    dueDate: Optional[str] = None
+    priority: str
+    tags: List[str] = Field(default_factory=list)
+    sortOrder: float
+    linkedTaskIds: List[str] = Field(default_factory=list)
+    activeWaitingCount: int = 0
+    createdAt: str
+
+
+class SubProjectEventCreate(BaseModel):
+    type: str = Field(pattern=r"^(waiting|note|decision)$")
+    title: str
+    body: Optional[str] = None
+    waitingOn: Optional[str] = None
+
+
+class SubProjectEventUpdate(BaseModel):
+    title: Optional[str] = None
+    body: Optional[str] = None
+    waitingOn: Optional[str] = None
+    resolvedAt: Optional[str] = None
+
+
+class SubProjectEventOut(BaseModel):
+    id: str
+    parentType: str
+    parentId: str
+    type: str
+    title: str
+    body: Optional[str] = None
+    waitingOn: Optional[str] = None
+    startedAt: str
+    resolvedAt: Optional[str] = None
+    createdAt: str
 
 
 # ---------------------------------------------------------------------------

--- a/backend/models.py
+++ b/backend/models.py
@@ -242,6 +242,7 @@ class SubProjectEventCreate(BaseModel):
     title: str
     body: Optional[str] = None
     waitingOn: Optional[str] = None
+    startedAt: Optional[str] = None
 
 
 class SubProjectEventUpdate(BaseModel):

--- a/backend/routers/sub_projects.py
+++ b/backend/routers/sub_projects.py
@@ -1,0 +1,519 @@
+"""Sub-project and sub-project event endpoints."""
+
+import json as _json
+import sqlite3
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+from uuid import uuid4
+
+from fastapi import APIRouter, Depends, HTTPException, status
+
+from auth import get_current_user
+from db import get_connection
+from models import (
+    SubProjectCreate,
+    SubProjectEventCreate,
+    SubProjectEventOut,
+    SubProjectEventUpdate,
+    SubProjectOut,
+    SubProjectUpdate,
+)
+from permissions import require_member_or_admin
+
+router = APIRouter(prefix="/api", tags=["sub_projects"])
+
+
+def utc_now() -> str:
+    return datetime.utcnow().isoformat()
+
+
+def _active_waiting_counts(
+    conn: sqlite3.Connection, sub_project_ids: List[str]
+) -> Dict[str, int]:
+    if not sub_project_ids:
+        return {}
+    placeholders = ",".join("?" * len(sub_project_ids))
+    rows = conn.execute(
+        f"""SELECT parent_id, COUNT(*) AS n FROM sub_project_events
+            WHERE parent_type = 'sub_project'
+              AND type = 'waiting'
+              AND resolved_at IS NULL
+              AND parent_id IN ({placeholders})
+            GROUP BY parent_id""",
+        sub_project_ids,
+    ).fetchall()
+    return {row["parent_id"]: row["n"] for row in rows}
+
+
+def _linked_task_ids(
+    conn: sqlite3.Connection, sub_project_ids: List[str]
+) -> Dict[str, List[str]]:
+    if not sub_project_ids:
+        return {}
+    placeholders = ",".join("?" * len(sub_project_ids))
+    rows = conn.execute(
+        f"SELECT sub_project_id, task_id FROM sub_project_tasks "
+        f"WHERE sub_project_id IN ({placeholders})",
+        sub_project_ids,
+    ).fetchall()
+    result: Dict[str, List[str]] = {sid: [] for sid in sub_project_ids}
+    for row in rows:
+        result.setdefault(row["sub_project_id"], []).append(row["task_id"])
+    return result
+
+
+def row_to_sub_project(
+    row: sqlite3.Row,
+    linked_task_ids: Optional[List[str]] = None,
+    active_waiting_count: int = 0,
+) -> Dict[str, Any]:
+    return {
+        "id": row["id"],
+        "burnupProjectId": row["burnup_project_id"],
+        "name": row["name"],
+        "description": row["description"] or None,
+        "status": row["status"],
+        "owner": row["owner"] or None,
+        "dueDate": row["due_date"] or None,
+        "priority": row["priority"],
+        "tags": _json.loads(row["tags"]) if row["tags"] else [],
+        "sortOrder": row["sort_order"],
+        "linkedTaskIds": linked_task_ids or [],
+        "activeWaitingCount": active_waiting_count,
+        "createdAt": row["created_at"],
+    }
+
+
+def row_to_event(row: sqlite3.Row) -> Dict[str, Any]:
+    return {
+        "id": row["id"],
+        "parentType": row["parent_type"],
+        "parentId": row["parent_id"],
+        "type": row["type"],
+        "title": row["title"],
+        "body": row["body"] or None,
+        "waitingOn": row["waiting_on"] or None,
+        "startedAt": row["started_at"],
+        "resolvedAt": row["resolved_at"],
+        "createdAt": row["created_at"],
+    }
+
+
+def _validate_task_ids(conn: sqlite3.Connection, task_ids: List[str]) -> None:
+    if not task_ids:
+        return
+    placeholders = ",".join("?" * len(task_ids))
+    rows = conn.execute(
+        f"SELECT id FROM tasks WHERE id IN ({placeholders})", task_ids
+    ).fetchall()
+    found = {row["id"] for row in rows}
+    missing = [tid for tid in task_ids if tid not in found]
+    if missing:
+        raise HTTPException(
+            status_code=400, detail=f"Unknown task ids: {', '.join(missing)}"
+        )
+
+
+def _replace_sub_project_tasks(
+    conn: sqlite3.Connection, sub_project_id: str, task_ids: List[str]
+) -> None:
+    conn.execute(
+        "DELETE FROM sub_project_tasks WHERE sub_project_id = ?", (sub_project_id,)
+    )
+    for tid in task_ids:
+        conn.execute(
+            "INSERT INTO sub_project_tasks (sub_project_id, task_id) VALUES (?, ?)",
+            (sub_project_id, tid),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Sub-project CRUD
+# ---------------------------------------------------------------------------
+
+
+@router.get(
+    "/projects/{burnup_project_id}/sub-projects",
+    response_model=List[SubProjectOut],
+)
+def list_sub_projects(
+    burnup_project_id: str,
+    _current_user: dict = Depends(get_current_user),
+) -> List[Dict[str, Any]]:
+    with get_connection() as conn:
+        project = conn.execute(
+            "SELECT 1 FROM projects WHERE id = ?", (burnup_project_id,)
+        ).fetchone()
+        if not project:
+            raise HTTPException(status_code=404, detail="Project not found")
+        rows = conn.execute(
+            "SELECT * FROM sub_projects WHERE burnup_project_id = ? "
+            "ORDER BY sort_order, created_at",
+            (burnup_project_id,),
+        ).fetchall()
+        ids = [row["id"] for row in rows]
+        links = _linked_task_ids(conn, ids)
+        waiting_counts = _active_waiting_counts(conn, ids)
+    return [
+        row_to_sub_project(
+            row,
+            links.get(row["id"], []),
+            waiting_counts.get(row["id"], 0),
+        )
+        for row in rows
+    ]
+
+
+@router.get("/sub-projects", response_model=List[SubProjectOut])
+def list_all_sub_projects(
+    _current_user: dict = Depends(get_current_user),
+) -> List[Dict[str, Any]]:
+    with get_connection() as conn:
+        rows = conn.execute(
+            "SELECT * FROM sub_projects ORDER BY sort_order, created_at"
+        ).fetchall()
+        ids = [row["id"] for row in rows]
+        links = _linked_task_ids(conn, ids)
+        waiting_counts = _active_waiting_counts(conn, ids)
+    return [
+        row_to_sub_project(
+            row,
+            links.get(row["id"], []),
+            waiting_counts.get(row["id"], 0),
+        )
+        for row in rows
+    ]
+
+
+@router.post(
+    "/projects/{burnup_project_id}/sub-projects",
+    response_model=SubProjectOut,
+    status_code=status.HTTP_201_CREATED,
+)
+def create_sub_project(
+    burnup_project_id: str,
+    payload: SubProjectCreate,
+    current_user: dict = Depends(require_member_or_admin),
+) -> Dict[str, Any]:
+    sub_id = payload.id or f"sp_{uuid4().hex}"
+    now = utc_now()
+    with get_connection() as conn:
+        project = conn.execute(
+            "SELECT 1 FROM projects WHERE id = ?", (burnup_project_id,)
+        ).fetchone()
+        if not project:
+            raise HTTPException(status_code=404, detail="Project not found")
+        existing = conn.execute(
+            "SELECT 1 FROM sub_projects WHERE id = ?", (sub_id,)
+        ).fetchone()
+        if existing:
+            raise HTTPException(status_code=409, detail="Sub-project id already exists")
+        _validate_task_ids(conn, payload.linkedTaskIds)
+
+        conn.execute(
+            """INSERT INTO sub_projects (
+                id, burnup_project_id, name, description, status, owner,
+                due_date, priority, tags, sort_order, created_at, created_by
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            (
+                sub_id,
+                burnup_project_id,
+                payload.name,
+                payload.description,
+                payload.status,
+                payload.owner,
+                payload.dueDate,
+                payload.priority,
+                _json.dumps(payload.tags),
+                0,
+                now,
+                current_user["id"],
+            ),
+        )
+        _replace_sub_project_tasks(conn, sub_id, payload.linkedTaskIds)
+        conn.commit()
+
+        row = conn.execute(
+            "SELECT * FROM sub_projects WHERE id = ?", (sub_id,)
+        ).fetchone()
+    return row_to_sub_project(row, payload.linkedTaskIds, 0)
+
+
+@router.patch("/sub-projects/{sub_project_id}", response_model=SubProjectOut)
+def update_sub_project(
+    sub_project_id: str,
+    payload: SubProjectUpdate,
+    _current_user: dict = Depends(require_member_or_admin),
+) -> Dict[str, Any]:
+    with get_connection() as conn:
+        existing = conn.execute(
+            "SELECT 1 FROM sub_projects WHERE id = ?", (sub_project_id,)
+        ).fetchone()
+        if not existing:
+            raise HTTPException(status_code=404, detail="Sub-project not found")
+
+        fields: List[str] = []
+        values: List[Any] = []
+
+        if payload.name is not None:
+            fields.append("name = ?")
+            values.append(payload.name)
+        if payload.description is not None:
+            fields.append("description = ?")
+            values.append(payload.description)
+        if payload.status is not None:
+            fields.append("status = ?")
+            values.append(payload.status)
+        if payload.owner is not None:
+            fields.append("owner = ?")
+            values.append(payload.owner)
+        if payload.dueDate is not None:
+            fields.append("due_date = ?")
+            values.append(payload.dueDate)
+        if payload.priority is not None:
+            fields.append("priority = ?")
+            values.append(payload.priority)
+        if payload.tags is not None:
+            fields.append("tags = ?")
+            values.append(_json.dumps(payload.tags))
+        if payload.sortOrder is not None:
+            fields.append("sort_order = ?")
+            values.append(payload.sortOrder)
+
+        if fields:
+            values.append(sub_project_id)
+            conn.execute(
+                f"UPDATE sub_projects SET {', '.join(fields)} WHERE id = ?", values
+            )
+
+        if payload.linkedTaskIds is not None:
+            _validate_task_ids(conn, payload.linkedTaskIds)
+            _replace_sub_project_tasks(conn, sub_project_id, payload.linkedTaskIds)
+
+        conn.commit()
+
+        row = conn.execute(
+            "SELECT * FROM sub_projects WHERE id = ?", (sub_project_id,)
+        ).fetchone()
+        task_ids = [
+            r["task_id"]
+            for r in conn.execute(
+                "SELECT task_id FROM sub_project_tasks WHERE sub_project_id = ?",
+                (sub_project_id,),
+            ).fetchall()
+        ]
+        waiting = _active_waiting_counts(conn, [sub_project_id]).get(
+            sub_project_id, 0
+        )
+    return row_to_sub_project(row, task_ids, waiting)
+
+
+@router.delete(
+    "/sub-projects/{sub_project_id}", status_code=status.HTTP_204_NO_CONTENT
+)
+def delete_sub_project(
+    sub_project_id: str,
+    _current_user: dict = Depends(require_member_or_admin),
+) -> None:
+    with get_connection() as conn:
+        existing = conn.execute(
+            "SELECT 1 FROM sub_projects WHERE id = ?", (sub_project_id,)
+        ).fetchone()
+        if not existing:
+            raise HTTPException(status_code=404, detail="Sub-project not found")
+        # Manually cascade: events (polymorphic, no FK), and clear todo.sub_project_id
+        conn.execute(
+            "DELETE FROM sub_project_events "
+            "WHERE parent_type = 'sub_project' AND parent_id = ?",
+            (sub_project_id,),
+        )
+        conn.execute(
+            "UPDATE todos SET sub_project_id = NULL WHERE sub_project_id = ?",
+            (sub_project_id,),
+        )
+        # sub_project_tasks rows are cleared via ON DELETE CASCADE
+        conn.execute("DELETE FROM sub_projects WHERE id = ?", (sub_project_id,))
+        conn.commit()
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Event CRUD (sub-project and todo parents)
+# ---------------------------------------------------------------------------
+
+
+def _validate_parent(
+    conn: sqlite3.Connection, parent_type: str, parent_id: str
+) -> None:
+    if parent_type == "sub_project":
+        row = conn.execute(
+            "SELECT 1 FROM sub_projects WHERE id = ?", (parent_id,)
+        ).fetchone()
+        if not row:
+            raise HTTPException(status_code=404, detail="Sub-project not found")
+    elif parent_type == "todo":
+        row = conn.execute(
+            "SELECT 1 FROM todos WHERE id = ?", (parent_id,)
+        ).fetchone()
+        if not row:
+            raise HTTPException(status_code=404, detail="Todo not found")
+    else:
+        raise HTTPException(status_code=400, detail="Invalid parent_type")
+
+
+def _create_event(
+    conn: sqlite3.Connection,
+    parent_type: str,
+    parent_id: str,
+    payload: SubProjectEventCreate,
+    user_id: str,
+) -> Dict[str, Any]:
+    event_id = f"spe_{uuid4().hex}"
+    now = utc_now()
+    conn.execute(
+        """INSERT INTO sub_project_events (
+            id, parent_type, parent_id, type, title, body, waiting_on,
+            started_at, resolved_at, created_at, created_by
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, NULL, ?, ?)""",
+        (
+            event_id,
+            parent_type,
+            parent_id,
+            payload.type,
+            payload.title,
+            payload.body,
+            payload.waitingOn if payload.type == "waiting" else None,
+            now,
+            now,
+            user_id,
+        ),
+    )
+    conn.commit()
+    row = conn.execute(
+        "SELECT * FROM sub_project_events WHERE id = ?", (event_id,)
+    ).fetchone()
+    return row_to_event(row)
+
+
+@router.get(
+    "/sub-projects/{sub_project_id}/events",
+    response_model=List[SubProjectEventOut],
+)
+def list_sub_project_events(
+    sub_project_id: str,
+    _current_user: dict = Depends(get_current_user),
+) -> List[Dict[str, Any]]:
+    with get_connection() as conn:
+        _validate_parent(conn, "sub_project", sub_project_id)
+        rows = conn.execute(
+            "SELECT * FROM sub_project_events "
+            "WHERE parent_type = 'sub_project' AND parent_id = ? "
+            "ORDER BY created_at DESC",
+            (sub_project_id,),
+        ).fetchall()
+    return [row_to_event(row) for row in rows]
+
+
+@router.post(
+    "/sub-projects/{sub_project_id}/events",
+    response_model=SubProjectEventOut,
+    status_code=status.HTTP_201_CREATED,
+)
+def create_sub_project_event(
+    sub_project_id: str,
+    payload: SubProjectEventCreate,
+    current_user: dict = Depends(require_member_or_admin),
+) -> Dict[str, Any]:
+    with get_connection() as conn:
+        _validate_parent(conn, "sub_project", sub_project_id)
+        return _create_event(
+            conn, "sub_project", sub_project_id, payload, current_user["id"]
+        )
+
+
+@router.get("/todos/{todo_id}/events", response_model=List[SubProjectEventOut])
+def list_todo_events(
+    todo_id: str,
+    _current_user: dict = Depends(get_current_user),
+) -> List[Dict[str, Any]]:
+    with get_connection() as conn:
+        _validate_parent(conn, "todo", todo_id)
+        rows = conn.execute(
+            "SELECT * FROM sub_project_events "
+            "WHERE parent_type = 'todo' AND parent_id = ? "
+            "ORDER BY created_at DESC",
+            (todo_id,),
+        ).fetchall()
+    return [row_to_event(row) for row in rows]
+
+
+@router.post(
+    "/todos/{todo_id}/events",
+    response_model=SubProjectEventOut,
+    status_code=status.HTTP_201_CREATED,
+)
+def create_todo_event(
+    todo_id: str,
+    payload: SubProjectEventCreate,
+    current_user: dict = Depends(require_member_or_admin),
+) -> Dict[str, Any]:
+    with get_connection() as conn:
+        _validate_parent(conn, "todo", todo_id)
+        return _create_event(conn, "todo", todo_id, payload, current_user["id"])
+
+
+@router.patch("/events/{event_id}", response_model=SubProjectEventOut)
+def update_event(
+    event_id: str,
+    payload: SubProjectEventUpdate,
+    _current_user: dict = Depends(require_member_or_admin),
+) -> Dict[str, Any]:
+    with get_connection() as conn:
+        existing = conn.execute(
+            "SELECT 1 FROM sub_project_events WHERE id = ?", (event_id,)
+        ).fetchone()
+        if not existing:
+            raise HTTPException(status_code=404, detail="Event not found")
+
+        fields: List[str] = []
+        values: List[Any] = []
+        if payload.title is not None:
+            fields.append("title = ?")
+            values.append(payload.title)
+        if payload.body is not None:
+            fields.append("body = ?")
+            values.append(payload.body)
+        if payload.waitingOn is not None:
+            fields.append("waiting_on = ?")
+            values.append(payload.waitingOn)
+        if payload.resolvedAt is not None:
+            fields.append("resolved_at = ?")
+            values.append(payload.resolvedAt or None)
+
+        if fields:
+            values.append(event_id)
+            conn.execute(
+                f"UPDATE sub_project_events SET {', '.join(fields)} WHERE id = ?",
+                values,
+            )
+            conn.commit()
+
+        row = conn.execute(
+            "SELECT * FROM sub_project_events WHERE id = ?", (event_id,)
+        ).fetchone()
+    return row_to_event(row)
+
+
+@router.delete("/events/{event_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_event(
+    event_id: str,
+    _current_user: dict = Depends(require_member_or_admin),
+) -> None:
+    with get_connection() as conn:
+        result = conn.execute(
+            "DELETE FROM sub_project_events WHERE id = ?", (event_id,)
+        )
+        conn.commit()
+    if result.rowcount == 0:
+        raise HTTPException(status_code=404, detail="Event not found")
+    return None

--- a/backend/routers/sub_projects.py
+++ b/backend/routers/sub_projects.py
@@ -364,6 +364,7 @@ def _create_event(
 ) -> Dict[str, Any]:
     event_id = f"spe_{uuid4().hex}"
     now = utc_now()
+    started = payload.startedAt or now
     conn.execute(
         """INSERT INTO sub_project_events (
             id, parent_type, parent_id, type, title, body, waiting_on,
@@ -377,7 +378,7 @@ def _create_event(
             payload.title,
             payload.body,
             payload.waitingOn if payload.type == "waiting" else None,
-            now,
+            started,
             now,
             user_id,
         ),

--- a/backend/routers/sub_projects.py
+++ b/backend/routers/sub_projects.py
@@ -302,15 +302,11 @@ def update_sub_project(
                 (sub_project_id,),
             ).fetchall()
         ]
-        waiting = _active_waiting_counts(conn, [sub_project_id]).get(
-            sub_project_id, 0
-        )
+        waiting = _active_waiting_counts(conn, [sub_project_id]).get(sub_project_id, 0)
     return row_to_sub_project(row, task_ids, waiting)
 
 
-@router.delete(
-    "/sub-projects/{sub_project_id}", status_code=status.HTTP_204_NO_CONTENT
-)
+@router.delete("/sub-projects/{sub_project_id}", status_code=status.HTTP_204_NO_CONTENT)
 def delete_sub_project(
     sub_project_id: str,
     _current_user: dict = Depends(require_member_or_admin),
@@ -352,9 +348,7 @@ def _validate_parent(
         if not row:
             raise HTTPException(status_code=404, detail="Sub-project not found")
     elif parent_type == "todo":
-        row = conn.execute(
-            "SELECT 1 FROM todos WHERE id = ?", (parent_id,)
-        ).fetchone()
+        row = conn.execute("SELECT 1 FROM todos WHERE id = ?", (parent_id,)).fetchone()
         if not row:
             raise HTTPException(status_code=404, detail="Todo not found")
     else:

--- a/backend/routers/todos.py
+++ b/backend/routers/todos.py
@@ -202,9 +202,7 @@ def update_todo(
                     (payload.subProjectId,),
                 ).fetchone()
                 if not sp_row:
-                    raise HTTPException(
-                        status_code=400, detail="Sub-project not found"
-                    )
+                    raise HTTPException(status_code=400, detail="Sub-project not found")
             fields.append("sub_project_id = ?")
             values.append(payload.subProjectId or None)
         if payload.sortOrder is not None:

--- a/backend/routers/todos.py
+++ b/backend/routers/todos.py
@@ -50,6 +50,7 @@ def row_to_todo(
         "tags": _json.loads(row["tags"]) if row["tags"] else [],
         "note": normalize_text(row["note"]) or None,
         "linkedTaskId": normalize_text(row["linked_task_id"]) or None,
+        "subProjectId": normalize_text(row["sub_project_id"]) or None,
         "createdAt": row["created_at"],
         "sortOrder": row["sort_order"],
         "comments": comments or [],
@@ -118,10 +119,17 @@ def create_todo(
             if not task_row:
                 raise HTTPException(status_code=404, detail="Linked task not found")
 
+        if payload.subProjectId:
+            sp_row = conn.execute(
+                "SELECT 1 FROM sub_projects WHERE id = ?", (payload.subProjectId,)
+            ).fetchone()
+            if not sp_row:
+                raise HTTPException(status_code=400, detail="Sub-project not found")
+
         conn.execute(
             """INSERT INTO todos (id, title, status, priority, due_date, assignee,
-               tags, note, linked_task_id, created_at, sort_order)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+               tags, note, linked_task_id, sub_project_id, created_at, sort_order)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
             (
                 todo_id,
                 payload.title,
@@ -132,6 +140,7 @@ def create_todo(
                 _json.dumps(payload.tags),
                 payload.note or "",
                 payload.linkedTaskId or None,
+                payload.subProjectId or None,
                 now,
                 0,
             ),
@@ -186,6 +195,18 @@ def update_todo(
         if payload.linkedTaskId is not None:
             fields.append("linked_task_id = ?")
             values.append(payload.linkedTaskId)
+        if payload.subProjectId is not None:
+            if payload.subProjectId:
+                sp_row = conn.execute(
+                    "SELECT 1 FROM sub_projects WHERE id = ?",
+                    (payload.subProjectId,),
+                ).fetchone()
+                if not sp_row:
+                    raise HTTPException(
+                        status_code=400, detail="Sub-project not found"
+                    )
+            fields.append("sub_project_id = ?")
+            values.append(payload.subProjectId or None)
         if payload.sortOrder is not None:
             fields.append("sort_order = ?")
             values.append(payload.sortOrder)

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -1119,3 +1119,295 @@ def test_update_user_no_changes(client: TestClient, auth: Dict[str, str]) -> Non
     )
     assert resp.status_code == 200
     assert resp.json()["username"] == "nochange"
+
+
+# ---------------------------------------------------------------------------
+# Sub-project tests
+# ---------------------------------------------------------------------------
+
+
+def _make_sub_project(
+    client: TestClient,
+    auth: Dict[str, str],
+    project_id: str,
+    **overrides: Any,
+) -> Dict[str, Any]:
+    payload: Dict[str, Any] = {"name": "SP one", "priority": "high"}
+    payload.update(overrides)
+    resp = client.post(
+        f"/api/projects/{project_id}/sub-projects",
+        json=payload,
+        headers=auth,
+    )
+    assert resp.status_code == 201, resp.text
+    return resp.json()
+
+
+def test_sub_project_crud(client: TestClient, auth: Dict[str, str]) -> None:
+    project = create_project(client, "Big", headers=auth)
+    sp = _make_sub_project(
+        client,
+        auth,
+        project["id"],
+        name="Login rewrite",
+        description="auth overhaul",
+        owner="alice",
+        dueDate="2026-05-01",
+        tags=["auth", "sec"],
+    )
+    assert sp["name"] == "Login rewrite"
+    assert sp["burnupProjectId"] == project["id"]
+    assert sp["activeWaitingCount"] == 0
+    assert sp["linkedTaskIds"] == []
+    assert sp["tags"] == ["auth", "sec"]
+
+    # list by burnup project
+    resp = client.get(
+        f"/api/projects/{project['id']}/sub-projects", headers=auth
+    )
+    assert resp.status_code == 200
+    assert len(resp.json()) == 1
+
+    # list all
+    resp = client.get("/api/sub-projects", headers=auth)
+    assert resp.status_code == 200
+    assert len(resp.json()) == 1
+
+    # update
+    resp = client.patch(
+        f"/api/sub-projects/{sp['id']}",
+        json={"status": "paused", "description": "on hold"},
+        headers=auth,
+    )
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "paused"
+    assert resp.json()["description"] == "on hold"
+
+    # delete
+    resp = client.delete(f"/api/sub-projects/{sp['id']}", headers=auth)
+    assert resp.status_code == 204
+    resp = client.get(
+        f"/api/projects/{project['id']}/sub-projects", headers=auth
+    )
+    assert resp.json() == []
+
+
+def test_sub_project_link_multiple_tasks(
+    client: TestClient, auth: Dict[str, str]
+) -> None:
+    project = create_project(client, "Big", headers=auth)
+    task_a = create_task(client, project["id"], "A", headers=auth)
+    task_b = create_task(client, project["id"], "B", headers=auth)
+
+    sp = _make_sub_project(
+        client,
+        auth,
+        project["id"],
+        linkedTaskIds=[task_a["id"], task_b["id"]],
+    )
+    assert set(sp["linkedTaskIds"]) == {task_a["id"], task_b["id"]}
+
+    # replace via update
+    resp = client.patch(
+        f"/api/sub-projects/{sp['id']}",
+        json={"linkedTaskIds": [task_a["id"]]},
+        headers=auth,
+    )
+    assert resp.status_code == 200
+    assert resp.json()["linkedTaskIds"] == [task_a["id"]]
+
+
+def test_sub_project_link_unknown_task_rejected(
+    client: TestClient, auth: Dict[str, str]
+) -> None:
+    project = create_project(client, "Big", headers=auth)
+    resp = client.post(
+        f"/api/projects/{project['id']}/sub-projects",
+        json={"name": "x", "linkedTaskIds": ["bogus_task"]},
+        headers=auth,
+    )
+    assert resp.status_code == 400
+
+
+def test_sub_project_event_crud(
+    client: TestClient, auth: Dict[str, str]
+) -> None:
+    project = create_project(client, "Big", headers=auth)
+    sp = _make_sub_project(client, auth, project["id"])
+
+    # create waiting event
+    resp = client.post(
+        f"/api/sub-projects/{sp['id']}/events",
+        json={"type": "waiting", "title": "waiting for PM", "waitingOn": "PM"},
+        headers=auth,
+    )
+    assert resp.status_code == 201
+    event = resp.json()
+    assert event["type"] == "waiting"
+    assert event["waitingOn"] == "PM"
+    assert event["resolvedAt"] is None
+
+    # create note event
+    resp = client.post(
+        f"/api/sub-projects/{sp['id']}/events",
+        json={"type": "note", "title": "kickoff meeting done"},
+        headers=auth,
+    )
+    assert resp.status_code == 201
+
+    # list events
+    resp = client.get(
+        f"/api/sub-projects/{sp['id']}/events", headers=auth
+    )
+    assert resp.status_code == 200
+    assert len(resp.json()) == 2
+
+    # waiting count on sub-project
+    resp = client.get(
+        f"/api/projects/{project['id']}/sub-projects", headers=auth
+    )
+    assert resp.json()[0]["activeWaitingCount"] == 1
+
+    # resolve the waiting event
+    resp = client.patch(
+        f"/api/events/{event['id']}",
+        json={"resolvedAt": "2026-04-20T10:00:00"},
+        headers=auth,
+    )
+    assert resp.status_code == 200
+    assert resp.json()["resolvedAt"] == "2026-04-20T10:00:00"
+
+    # waiting count now 0
+    resp = client.get(
+        f"/api/projects/{project['id']}/sub-projects", headers=auth
+    )
+    assert resp.json()[0]["activeWaitingCount"] == 0
+
+    # delete event
+    resp = client.delete(f"/api/events/{event['id']}", headers=auth)
+    assert resp.status_code == 204
+
+
+def test_sub_project_event_invalid_type_rejected(
+    client: TestClient, auth: Dict[str, str]
+) -> None:
+    project = create_project(client, "Big", headers=auth)
+    sp = _make_sub_project(client, auth, project["id"])
+    resp = client.post(
+        f"/api/sub-projects/{sp['id']}/events",
+        json={"type": "bogus", "title": "x"},
+        headers=auth,
+    )
+    assert resp.status_code == 422
+
+
+def test_sub_project_event_parent_must_exist(
+    client: TestClient, auth: Dict[str, str]
+) -> None:
+    resp = client.post(
+        "/api/sub-projects/nonexistent/events",
+        json={"type": "note", "title": "x"},
+        headers=auth,
+    )
+    assert resp.status_code == 404
+
+    resp = client.post(
+        "/api/todos/nonexistent/events",
+        json={"type": "note", "title": "x"},
+        headers=auth,
+    )
+    assert resp.status_code == 404
+
+
+def test_todo_event_crud(client: TestClient, auth: Dict[str, str]) -> None:
+    resp = client.post(
+        "/api/todos", json={"title": "t"}, headers=auth
+    )
+    assert resp.status_code == 201
+    todo_id = resp.json()["id"]
+
+    resp = client.post(
+        f"/api/todos/{todo_id}/events",
+        json={"type": "waiting", "title": "waiting for review", "waitingOn": "Lead"},
+        headers=auth,
+    )
+    assert resp.status_code == 201
+    assert resp.json()["parentType"] == "todo"
+
+    resp = client.get(f"/api/todos/{todo_id}/events", headers=auth)
+    assert resp.status_code == 200
+    assert len(resp.json()) == 1
+
+
+def test_todo_sub_project_link(
+    client: TestClient, auth: Dict[str, str]
+) -> None:
+    project = create_project(client, "Big", headers=auth)
+    sp = _make_sub_project(client, auth, project["id"])
+
+    # create todo with sub_project_id
+    resp = client.post(
+        "/api/todos",
+        json={"title": "t", "subProjectId": sp["id"]},
+        headers=auth,
+    )
+    assert resp.status_code == 201
+    todo = resp.json()
+    assert todo["subProjectId"] == sp["id"]
+
+    # create todo with unknown sub_project_id → 400
+    resp = client.post(
+        "/api/todos",
+        json={"title": "t2", "subProjectId": "bogus"},
+        headers=auth,
+    )
+    assert resp.status_code == 400
+
+    # update to clear
+    resp = client.patch(
+        f"/api/todos/{todo['id']}",
+        json={"subProjectId": ""},
+        headers=auth,
+    )
+    assert resp.status_code == 200
+    assert resp.json()["subProjectId"] is None
+
+    # update to set
+    resp = client.patch(
+        f"/api/todos/{todo['id']}",
+        json={"subProjectId": sp["id"]},
+        headers=auth,
+    )
+    assert resp.status_code == 200
+    assert resp.json()["subProjectId"] == sp["id"]
+
+
+def test_cascade_delete_sub_project_clears_todo_and_events(
+    client: TestClient, auth: Dict[str, str]
+) -> None:
+    project = create_project(client, "Big", headers=auth)
+    sp = _make_sub_project(client, auth, project["id"])
+
+    # create an event
+    client.post(
+        f"/api/sub-projects/{sp['id']}/events",
+        json={"type": "waiting", "title": "w"},
+        headers=auth,
+    )
+    # create a todo linked to sub-project
+    resp = client.post(
+        "/api/todos",
+        json={"title": "t", "subProjectId": sp["id"]},
+        headers=auth,
+    )
+    todo_id = resp.json()["id"]
+
+    # delete sub-project
+    resp = client.delete(f"/api/sub-projects/{sp['id']}", headers=auth)
+    assert resp.status_code == 204
+
+    # todo still exists but sub_project_id cleared
+    resp = client.get("/api/todos", headers=auth)
+    todos = [t for t in resp.json() if t["id"] == todo_id]
+    assert len(todos) == 1
+    assert todos[0]["subProjectId"] is None

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -1162,9 +1162,7 @@ def test_sub_project_crud(client: TestClient, auth: Dict[str, str]) -> None:
     assert sp["tags"] == ["auth", "sec"]
 
     # list by burnup project
-    resp = client.get(
-        f"/api/projects/{project['id']}/sub-projects", headers=auth
-    )
+    resp = client.get(f"/api/projects/{project['id']}/sub-projects", headers=auth)
     assert resp.status_code == 200
     assert len(resp.json()) == 1
 
@@ -1186,9 +1184,7 @@ def test_sub_project_crud(client: TestClient, auth: Dict[str, str]) -> None:
     # delete
     resp = client.delete(f"/api/sub-projects/{sp['id']}", headers=auth)
     assert resp.status_code == 204
-    resp = client.get(
-        f"/api/projects/{project['id']}/sub-projects", headers=auth
-    )
+    resp = client.get(f"/api/projects/{project['id']}/sub-projects", headers=auth)
     assert resp.json() == []
 
 
@@ -1229,9 +1225,7 @@ def test_sub_project_link_unknown_task_rejected(
     assert resp.status_code == 400
 
 
-def test_sub_project_event_crud(
-    client: TestClient, auth: Dict[str, str]
-) -> None:
+def test_sub_project_event_crud(client: TestClient, auth: Dict[str, str]) -> None:
     project = create_project(client, "Big", headers=auth)
     sp = _make_sub_project(client, auth, project["id"])
 
@@ -1256,16 +1250,12 @@ def test_sub_project_event_crud(
     assert resp.status_code == 201
 
     # list events
-    resp = client.get(
-        f"/api/sub-projects/{sp['id']}/events", headers=auth
-    )
+    resp = client.get(f"/api/sub-projects/{sp['id']}/events", headers=auth)
     assert resp.status_code == 200
     assert len(resp.json()) == 2
 
     # waiting count on sub-project
-    resp = client.get(
-        f"/api/projects/{project['id']}/sub-projects", headers=auth
-    )
+    resp = client.get(f"/api/projects/{project['id']}/sub-projects", headers=auth)
     assert resp.json()[0]["activeWaitingCount"] == 1
 
     # resolve the waiting event
@@ -1278,9 +1268,7 @@ def test_sub_project_event_crud(
     assert resp.json()["resolvedAt"] == "2026-04-20T10:00:00"
 
     # waiting count now 0
-    resp = client.get(
-        f"/api/projects/{project['id']}/sub-projects", headers=auth
-    )
+    resp = client.get(f"/api/projects/{project['id']}/sub-projects", headers=auth)
     assert resp.json()[0]["activeWaitingCount"] == 0
 
     # delete event
@@ -1320,9 +1308,7 @@ def test_sub_project_event_parent_must_exist(
 
 
 def test_todo_event_crud(client: TestClient, auth: Dict[str, str]) -> None:
-    resp = client.post(
-        "/api/todos", json={"title": "t"}, headers=auth
-    )
+    resp = client.post("/api/todos", json={"title": "t"}, headers=auth)
     assert resp.status_code == 201
     todo_id = resp.json()["id"]
 
@@ -1339,9 +1325,7 @@ def test_todo_event_crud(client: TestClient, auth: Dict[str, str]) -> None:
     assert len(resp.json()) == 1
 
 
-def test_todo_sub_project_link(
-    client: TestClient, auth: Dict[str, str]
-) -> None:
+def test_todo_sub_project_link(client: TestClient, auth: Dict[str, str]) -> None:
     project = create_project(client, "Big", headers=auth)
     sp = _make_sub_project(client, auth, project["id"])
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "date-holidays": "^3.26.5",
+        "fuse.js": "^7.3.0",
         "lucide-react": "^0.453.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -4133,6 +4134,19 @@
       "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/fuse.js": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-7.3.0.tgz",
+      "integrity": "sha512-plz8RVjfcDedTGfVngWH1jmJvBvAwi1v2jecfDerbEnMcmOYUEEwKFTHbNoCiYyzaK2Ws8lABkTCcRSqCY1q4w==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/krisk"
       }
     },
     "node_modules/generator-function": {
@@ -10446,6 +10460,11 @@
       "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
       "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
       "dev": true
+    },
+    "fuse.js": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-7.3.0.tgz",
+      "integrity": "sha512-plz8RVjfcDedTGfVngWH1jmJvBvAwi1v2jecfDerbEnMcmOYUEEwKFTHbNoCiYyzaK2Ws8lABkTCcRSqCY1q4w=="
     },
     "generator-function": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "date-holidays": "^3.26.5",
+    "fuse.js": "^7.3.0",
     "lucide-react": "^0.453.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,6 +4,7 @@ import { Upload, Download, Plus, Trash2, Calendar, User, AlertTriangle, CheckCir
 import Holidays from 'date-holidays';
 import TodoBoard from './components/TodoBoard';
 import TodoSection from './components/TodoSection';
+import SubProjectSection from './components/SubProjectSection';
 import { requestJson } from './api';
 import { useAuth } from './auth/AuthContext';
 import LoginPage from './auth/LoginPage';
@@ -446,6 +447,7 @@ function BurnupChartInner({ showAdminPanel: _showAdminPanel, setShowAdminPanel }
   // Todo & Status State
   const [todos, setTodos] = useState([]);
   const [statuses, setStatuses] = useState([]);
+  const [subProjects, setSubProjects] = useState([]);
   const [pendingEditTodoId, setPendingEditTodoId] = useState(null);
 
   const { getExpectedEndDate, getExpectedPoints, loading: _holidayLoading } = useTaiwanCalendar();
@@ -495,6 +497,10 @@ function BurnupChartInner({ showAdminPanel: _showAdminPanel, setShowAdminPanel }
           const todoData = await requestJson("/api/todos");
           if (isActive) setTodos(Array.isArray(todoData) ? todoData : []);
         } catch {}
+        try {
+          const subProjectData = await requestJson("/api/sub-projects");
+          if (isActive) setSubProjects(Array.isArray(subProjectData) ? subProjectData : []);
+        } catch {}
       } catch (_err) {
         if (!isActive) return;
         setApiAvailable(false);
@@ -516,17 +522,65 @@ function BurnupChartInner({ showAdminPanel: _showAdminPanel, setShowAdminPanel }
     let isActive = true;
     (async () => {
       try {
-        const [statusData, todoData] = await Promise.all([
+        const [statusData, todoData, subProjectData] = await Promise.all([
           requestJson("/api/statuses"),
           requestJson("/api/todos"),
+          requestJson("/api/sub-projects"),
         ]);
         if (!isActive) return;
         setStatuses(Array.isArray(statusData) ? statusData : []);
         setTodos(Array.isArray(todoData) ? todoData : []);
+        setSubProjects(Array.isArray(subProjectData) ? subProjectData : []);
       } catch {}
     })();
     return () => { isActive = false; };
   }, [activeProjectId, apiAvailable]);
+
+  const reloadSubProjects = useCallback(async () => {
+    if (!apiAvailable) return;
+    try {
+      const data = await requestJson("/api/sub-projects");
+      setSubProjects(Array.isArray(data) ? data : []);
+    } catch {}
+  }, [apiAvailable]);
+
+  const handleCreateSubProject = useCallback(async (burnupProjectId, data) => {
+    if (!apiAvailable) return;
+    try {
+      const created = await requestJson(`/api/projects/${burnupProjectId}/sub-projects`, {
+        method: 'POST',
+        body: JSON.stringify(data),
+      });
+      setSubProjects(prev => [...prev, created]);
+    } catch (err) {
+      console.error('Failed to create sub-project', err);
+    }
+  }, [apiAvailable]);
+
+  const handleUpdateSubProject = useCallback(async (id, data) => {
+    if (!apiAvailable) return;
+    try {
+      const updated = await requestJson(`/api/sub-projects/${id}`, {
+        method: 'PATCH',
+        body: JSON.stringify(data),
+      });
+      setSubProjects(prev => prev.map(sp => sp.id === id ? updated : sp));
+    } catch (err) {
+      console.error('Failed to update sub-project', err);
+    }
+  }, [apiAvailable]);
+
+  const handleDeleteSubProject = useCallback(async (id) => {
+    if (!apiAvailable) return;
+    try {
+      await requestJson(`/api/sub-projects/${id}`, { method: 'DELETE' });
+      setSubProjects(prev => prev.filter(sp => sp.id !== id));
+      // Clear sub_project_id from local todos matching
+      setTodos(prev => prev.map(t => t.subProjectId === id ? { ...t, subProjectId: null } : t));
+    } catch (err) {
+      console.error('Failed to delete sub-project', err);
+    }
+  }, [apiAvailable]);
 
   const fileInputRef = useRef(null);
 
@@ -2351,6 +2405,7 @@ function BurnupChartInner({ showAdminPanel: _showAdminPanel, setShowAdminPanel }
               statuses={statuses}
               allTasks={allTasksFlat}
               projects={projects}
+              subProjects={subProjects}
               onCreateTodo={createTodo}
               onUpdateTodo={updateTodo}
               onDeleteTodo={deleteTodo}
@@ -2851,6 +2906,19 @@ function BurnupChartInner({ showAdminPanel: _showAdminPanel, setShowAdminPanel }
             </div>
           </div>
         </div>
+
+        {/* Sub-projects: only when a specific project is selected (not merged view) */}
+        {activeProjectId !== MERGED_TAB_ID && activeProject && (
+          <SubProjectSection
+            burnupProjectId={activeProject.id}
+            subProjects={subProjects}
+            tasks={allTasks}
+            onCreate={handleCreateSubProject}
+            onUpdate={handleUpdateSubProject}
+            onDelete={handleDeleteSubProject}
+            onReload={reloadSubProjects}
+          />
+        )}
 
       </div>
       </>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,6 +6,7 @@ import TodoBoard from './components/TodoBoard';
 import TodoSection from './components/TodoSection';
 import SubProjectSection from './components/SubProjectSection';
 import SearchModal from './components/SearchModal';
+import KeyboardShortcutsHelp from './components/KeyboardShortcutsHelp';
 import { requestJson } from './api';
 import { useAuth } from './auth/AuthContext';
 import LoginPage from './auth/LoginPage';
@@ -2967,6 +2968,7 @@ function BurnupChartInner({ showAdminPanel: _showAdminPanel, setShowAdminPanel }
       </div>
       </>
       )}
+      <KeyboardShortcutsHelp />
     </div>
   );
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2420,6 +2420,24 @@ function BurnupChartInner({ showAdminPanel: _showAdminPanel, setShowAdminPanel }
               onClearInitialEditTodoId={() => setPendingEditTodoId(null)}
             />
           </div>
+          {/* Sub-projects section in Todo tab — grouped by burnup project */}
+          {projects.map(proj => {
+            const projSubs = subProjects.filter(sp => sp.burnupProjectId === proj.id);
+            if (projSubs.length === 0) return null;
+            return (
+              <SubProjectSection
+                key={proj.id}
+                burnupProjectId={proj.id}
+                burnupProjectName={proj.name}
+                subProjects={subProjects}
+                tasks={proj.tasks || []}
+                onCreate={handleCreateSubProject}
+                onUpdate={handleUpdateSubProject}
+                onDelete={handleDeleteSubProject}
+                onReload={reloadSubProjects}
+              />
+            );
+          })}
         </div>
       ) : (
       <>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,6 +5,7 @@ import Holidays from 'date-holidays';
 import TodoBoard from './components/TodoBoard';
 import TodoSection from './components/TodoSection';
 import SubProjectSection from './components/SubProjectSection';
+import SearchModal from './components/SearchModal';
 import { requestJson } from './api';
 import { useAuth } from './auth/AuthContext';
 import LoginPage from './auth/LoginPage';
@@ -448,6 +449,18 @@ function BurnupChartInner({ showAdminPanel: _showAdminPanel, setShowAdminPanel }
   const [todos, setTodos] = useState([]);
   const [statuses, setStatuses] = useState([]);
   const [subProjects, setSubProjects] = useState([]);
+  const [showSearch, setShowSearch] = useState(false);
+
+  useEffect(() => {
+    const onKey = (e) => {
+      if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
+        e.preventDefault();
+        setShowSearch(v => !v);
+      }
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, []);
   const [pendingEditTodoId, setPendingEditTodoId] = useState(null);
 
   const { getExpectedEndDate, getExpectedPoints, loading: _holidayLoading } = useTaiwanCalendar();
@@ -1968,6 +1981,19 @@ function BurnupChartInner({ showAdminPanel: _showAdminPanel, setShowAdminPanel }
 
   return (
     <div className="min-h-screen bg-gray-100 text-gray-800 font-sans pb-10">
+      {showSearch && (
+        <SearchModal
+          todos={todos}
+          subProjects={subProjects}
+          statuses={statuses}
+          onSelect={(todoId) => {
+            setShowSearch(false);
+            setPendingEditTodoId(todoId);
+            setActiveProjectId(TODO_TAB_ID);
+          }}
+          onClose={() => setShowSearch(false)}
+        />
+      )}
       <datalist id="people-options">
         {uniquePeople.map(person => (
           <option key={person} value={person} />

--- a/src/components/KeyboardShortcutsHelp.jsx
+++ b/src/components/KeyboardShortcutsHelp.jsx
@@ -1,0 +1,78 @@
+import React, { useState, useRef, useEffect } from 'react';
+import { Keyboard, X } from 'lucide-react';
+
+const isMac = navigator.platform.toUpperCase().indexOf('MAC') >= 0;
+const modKey = isMac ? '⌘' : 'Ctrl';
+
+const shortcuts = [
+  { keys: [`${modKey}`, 'K'], description: '開啟搜尋' },
+  { keys: ['↑', '↓'], description: '搜尋結果上下選取' },
+  { keys: ['Enter'], description: '開啟選中結果' },
+  { keys: ['Esc'], description: '關閉彈窗 / 搜尋' },
+];
+
+export default function KeyboardShortcutsHelp() {
+  const [open, setOpen] = useState(false);
+  const ref = useRef(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e) => {
+      if (ref.current && !ref.current.contains(e.target)) setOpen(false);
+    };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e) => {
+      if (e.key === 'Escape') setOpen(false);
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [open]);
+
+  return (
+    <div ref={ref} className="fixed bottom-5 right-5 z-50">
+      {open && (
+        <div className="absolute bottom-14 right-0 w-64 bg-white rounded-xl shadow-2xl border border-gray-200 overflow-hidden animate-in fade-in slide-in-from-bottom-2">
+          <div className="flex items-center justify-between px-4 py-2.5 bg-gray-50 border-b border-gray-100">
+            <span className="text-xs font-bold text-gray-600">快捷鍵</span>
+            <button onClick={() => setOpen(false)} className="text-gray-400 hover:text-gray-600 p-0.5 rounded hover:bg-gray-200 transition">
+              <X size={14} />
+            </button>
+          </div>
+          <div className="p-3 space-y-2">
+            {shortcuts.map((s, i) => (
+              <div key={i} className="flex items-center justify-between">
+                <span className="text-xs text-gray-600">{s.description}</span>
+                <div className="flex items-center gap-0.5">
+                  {s.keys.map((k, j) => (
+                    <React.Fragment key={j}>
+                      {j > 0 && <span className="text-[10px] text-gray-300 mx-0.5">+</span>}
+                      <kbd className="inline-flex items-center justify-center min-w-[22px] h-5 px-1.5 text-[11px] font-medium text-gray-600 bg-gray-100 border border-gray-300 rounded shadow-sm">
+                        {k}
+                      </kbd>
+                    </React.Fragment>
+                  ))}
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+      <button
+        onClick={() => setOpen(v => !v)}
+        className={`w-10 h-10 rounded-full shadow-lg flex items-center justify-center transition-all ${
+          open
+            ? 'bg-indigo-600 text-white shadow-indigo-200'
+            : 'bg-white text-gray-500 hover:text-indigo-600 hover:shadow-xl border border-gray-200'
+        }`}
+        title="快捷鍵說明"
+      >
+        <Keyboard size={18} />
+      </button>
+    </div>
+  );
+}

--- a/src/components/SearchModal.jsx
+++ b/src/components/SearchModal.jsx
@@ -1,0 +1,175 @@
+import React, { useState, useMemo, useEffect, useRef, useCallback } from 'react';
+import { Search, ArrowUp, ArrowDown, CornerDownLeft } from 'lucide-react';
+import Fuse from 'fuse.js';
+import { assigneeColor } from '../utils/assigneeColor';
+
+export default function SearchModal({ todos, subProjects, statuses, onSelect, onClose }) {
+  const [query, setQuery] = useState('');
+  const [activeIndex, setActiveIndex] = useState(0);
+  const inputRef = useRef(null);
+  const listRef = useRef(null);
+
+  const subProjectMap = useMemo(() => {
+    const m = new Map();
+    (subProjects || []).forEach(sp => m.set(sp.id, sp));
+    return m;
+  }, [subProjects]);
+
+  const statusMap = useMemo(() => {
+    const m = new Map();
+    (statuses || []).forEach(s => m.set(s.id, s));
+    return m;
+  }, [statuses]);
+
+  const enrichedTodos = useMemo(() =>
+    todos.map(t => ({
+      ...t,
+      _subProjectName: t.subProjectId ? (subProjectMap.get(t.subProjectId)?.name || '') : '',
+    })),
+    [todos, subProjectMap]
+  );
+
+  const fuse = useMemo(() =>
+    new Fuse(enrichedTodos, {
+      keys: [
+        { name: 'title', weight: 2 },
+        { name: 'assignee', weight: 1 },
+        { name: 'tags', weight: 1 },
+        { name: 'note', weight: 0.5 },
+        { name: '_subProjectName', weight: 1 },
+      ],
+      threshold: 0.4,
+      includeScore: true,
+    }),
+    [enrichedTodos]
+  );
+
+  const results = useMemo(() => {
+    if (!query.trim()) {
+      return [...enrichedTodos]
+        .sort((a, b) => (b.createdAt || '').localeCompare(a.createdAt || ''))
+        .slice(0, 10);
+    }
+    return fuse.search(query).slice(0, 20).map(r => r.item);
+  }, [query, fuse, enrichedTodos]);
+
+  const scrollToActive = useCallback(() => {
+    requestAnimationFrame(() => {
+      if (listRef.current) {
+        const active = listRef.current.querySelector('[data-active="true"]');
+        if (active) active.scrollIntoView({ block: 'nearest' });
+      }
+    });
+  }, []);
+
+  const handleKeyDown = useCallback((e) => {
+    if (e.nativeEvent?.isComposing || e.keyCode === 229) return;
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      setActiveIndex(i => Math.min(i + 1, results.length - 1));
+      scrollToActive();
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      setActiveIndex(i => Math.max(i - 1, 0));
+      scrollToActive();
+    } else if (e.key === 'Enter' && results.length > 0) {
+      e.preventDefault();
+      onSelect(results[activeIndex].id);
+    } else if (e.key === 'Escape') {
+      e.preventDefault();
+      onClose();
+    }
+  }, [results, activeIndex, onSelect, onClose, scrollToActive]);
+
+  useEffect(() => {
+    inputRef.current?.focus();
+  }, []);
+
+  return (
+    <div className="fixed inset-0 z-[90] bg-black/40" onClick={onClose}>
+      <div
+        className="max-w-lg w-full mx-auto mt-[15vh] bg-white rounded-xl shadow-2xl overflow-hidden flex flex-col"
+        style={{ maxHeight: '60vh' }}
+        onClick={e => e.stopPropagation()}
+      >
+        {/* Search input */}
+        <div className="flex items-center gap-2 px-4 py-3 border-b border-gray-100">
+          <Search size={18} className="text-gray-400 shrink-0" />
+          <input
+            ref={inputRef}
+            type="text"
+            value={query}
+            onChange={e => { setQuery(e.target.value); setActiveIndex(0); }}
+            onKeyDown={handleKeyDown}
+            className="flex-1 text-sm outline-none bg-transparent placeholder-gray-400"
+            placeholder="搜尋 Todo..."
+          />
+          {query && (
+            <button onClick={() => setQuery('')} className="text-xs text-gray-400 hover:text-gray-600">
+              清除
+            </button>
+          )}
+        </div>
+
+        {/* Results */}
+        <div ref={listRef} className="flex-1 overflow-y-auto">
+          {results.length === 0 ? (
+            <div className="text-center text-gray-400 text-sm py-8">
+              {query ? '找不到符合的 Todo' : '尚無 Todo'}
+            </div>
+          ) : (
+            <div className="py-1">
+              {!query && <p className="px-4 py-1 text-[11px] text-gray-400">最近的 Todo</p>}
+              {results.map((todo, i) => {
+                const isActive = i === activeIndex;
+                const status = statusMap.get(todo.status);
+                const sp = todo.subProjectId ? subProjectMap.get(todo.subProjectId) : null;
+                return (
+                  <div
+                    key={todo.id}
+                    data-active={isActive}
+                    onClick={() => onSelect(todo.id)}
+                    onMouseEnter={() => setActiveIndex(i)}
+                    className={`flex items-center gap-2 px-4 py-2 cursor-pointer transition-colors ${
+                      isActive ? 'bg-indigo-50' : 'hover:bg-gray-50'
+                    }`}
+                  >
+                    <div className="flex-1 min-w-0">
+                      <div className="flex items-center gap-1.5">
+                        <span className="text-sm text-gray-800 font-medium truncate">{todo.title}</span>
+                        {sp && (
+                          <span className="bg-violet-50 text-violet-700 px-1.5 py-0.5 rounded text-[10px] shrink-0">
+                            {sp.name}
+                          </span>
+                        )}
+                      </div>
+                    </div>
+                    <div className="flex items-center gap-1.5 shrink-0">
+                      {todo.assignee && (
+                        <div className={`w-5 h-5 rounded-full ${assigneeColor(todo.assignee)} text-white flex items-center justify-center text-[10px] font-bold`}>
+                          {todo.assignee.charAt(0).toUpperCase()}
+                        </div>
+                      )}
+                      {status && (
+                        <span className="text-[10px] px-1.5 py-0.5 rounded bg-gray-100 text-gray-600">
+                          {status.name}
+                        </span>
+                      )}
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </div>
+
+        {/* Footer hints */}
+        <div className="flex items-center gap-4 px-4 py-2 border-t border-gray-100 bg-gray-50 text-[11px] text-gray-400">
+          <span className="flex items-center gap-1"><ArrowUp size={10} /><ArrowDown size={10} /> 選擇</span>
+          <span className="flex items-center gap-1"><CornerDownLeft size={10} /> 開啟</span>
+          <span>esc 關閉</span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/SubProjectFormModal.jsx
+++ b/src/components/SubProjectFormModal.jsx
@@ -1,0 +1,250 @@
+import React, { useState, useMemo, useEffect } from 'react';
+import { X, Trash2 } from 'lucide-react';
+
+const STATUS_OPTIONS = [
+  { value: 'active', label: '進行中' },
+  { value: 'paused', label: '暫停' },
+  { value: 'done', label: '完成' },
+  { value: 'cancelled', label: '取消' },
+];
+
+export default function SubProjectFormModal({
+  subProject,
+  tasks,
+  onSave,
+  onDelete,
+  onClose,
+}) {
+  const isEdit = !!subProject;
+
+  const initialForm = useMemo(() => ({
+    name: subProject?.name || '',
+    description: subProject?.description || '',
+    status: subProject?.status || 'active',
+    owner: subProject?.owner || '',
+    dueDate: subProject?.dueDate || '',
+    priority: subProject?.priority || 'medium',
+    tags: subProject?.tags || [],
+    tagInput: '',
+    linkedTaskIds: subProject?.linkedTaskIds || [],
+  }), [subProject]);
+
+  const [form, setForm] = useState(initialForm);
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+
+  useEffect(() => {
+    const onKey = (e) => { if (e.key === 'Escape') onClose(); };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [onClose]);
+
+  const addTag = (value) => {
+    const tag = value.trim();
+    if (tag && !form.tags.includes(tag)) {
+      setForm(f => ({ ...f, tags: [...f.tags, tag], tagInput: '' }));
+    } else {
+      setForm(f => ({ ...f, tagInput: '' }));
+    }
+  };
+  const removeTag = (tag) => setForm(f => ({ ...f, tags: f.tags.filter(t => t !== tag) }));
+
+  const toggleTask = (taskId) => {
+    setForm(f => ({
+      ...f,
+      linkedTaskIds: f.linkedTaskIds.includes(taskId)
+        ? f.linkedTaskIds.filter(id => id !== taskId)
+        : [...f.linkedTaskIds, taskId],
+    }));
+  };
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    if (!form.name.trim()) return;
+    const finalTags = [...form.tags];
+    if (form.tagInput.trim() && !finalTags.includes(form.tagInput.trim())) {
+      finalTags.push(form.tagInput.trim());
+    }
+    onSave({
+      ...(subProject ? { id: subProject.id } : {}),
+      name: form.name.trim(),
+      description: form.description || null,
+      status: form.status,
+      owner: form.owner || null,
+      dueDate: form.dueDate || null,
+      priority: form.priority,
+      tags: finalTags,
+      linkedTaskIds: form.linkedTaskIds,
+    });
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-[80] p-4" onClick={onClose}>
+      <div className="bg-white rounded-xl shadow-2xl w-full max-w-lg max-h-[90vh] flex flex-col overflow-hidden" onClick={e => e.stopPropagation()}>
+        <div className="flex justify-between items-center p-4 border-b border-gray-100 shrink-0">
+          <h3 className="text-base font-bold text-gray-800">{isEdit ? '編輯 Sub-project' : '新增 Sub-project'}</h3>
+          <button onClick={onClose} className="p-1 rounded-full hover:bg-gray-100 text-gray-400 hover:text-gray-600">
+            <X size={20} />
+          </button>
+        </div>
+        <form onSubmit={handleSubmit} className="flex-1 flex flex-col min-h-0">
+          <div className="flex-1 overflow-y-auto p-4 space-y-3">
+            {/* Name */}
+            <div>
+              <label className="text-xs font-medium text-gray-600 block mb-1">名稱 *</label>
+              <input
+                type="text"
+                value={form.name}
+                onChange={e => setForm(f => ({ ...f, name: e.target.value }))}
+                className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:border-indigo-500 outline-none"
+                placeholder="例：登入改版"
+                autoFocus
+                data-1p-ignore
+                autoComplete="off"
+              />
+            </div>
+
+            {/* Description */}
+            <div>
+              <label className="text-xs font-medium text-gray-600 block mb-1">描述</label>
+              <textarea
+                value={form.description}
+                onChange={e => setForm(f => ({ ...f, description: e.target.value }))}
+                className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:border-indigo-500 outline-none resize-none"
+                rows={2}
+                placeholder="簡短描述..."
+                data-1p-ignore
+              />
+            </div>
+
+            {/* Status + Priority */}
+            <div className="grid grid-cols-2 gap-3">
+              <div>
+                <label className="text-xs font-medium text-gray-600 block mb-1">狀態</label>
+                <select
+                  value={form.status}
+                  onChange={e => setForm(f => ({ ...f, status: e.target.value }))}
+                  className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:border-indigo-500 outline-none"
+                >
+                  {STATUS_OPTIONS.map(o => <option key={o.value} value={o.value}>{o.label}</option>)}
+                </select>
+              </div>
+              <div>
+                <label className="text-xs font-medium text-gray-600 block mb-1">優先級</label>
+                <select
+                  value={form.priority}
+                  onChange={e => setForm(f => ({ ...f, priority: e.target.value }))}
+                  className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:border-indigo-500 outline-none"
+                >
+                  <option value="high">高</option>
+                  <option value="medium">中</option>
+                  <option value="low">低</option>
+                </select>
+              </div>
+            </div>
+
+            {/* Owner + Due date */}
+            <div className="grid grid-cols-2 gap-3">
+              <div>
+                <label className="text-xs font-medium text-gray-600 block mb-1">負責人</label>
+                <input
+                  type="text"
+                  value={form.owner}
+                  onChange={e => setForm(f => ({ ...f, owner: e.target.value }))}
+                  className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:border-indigo-500 outline-none"
+                  placeholder="例：Alice"
+                  data-1p-ignore
+                  autoComplete="off"
+                />
+              </div>
+              <div>
+                <label className="text-xs font-medium text-gray-600 block mb-1">目標完成日</label>
+                <input
+                  type="date"
+                  value={form.dueDate}
+                  onChange={e => setForm(f => ({ ...f, dueDate: e.target.value }))}
+                  className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:border-indigo-500 outline-none"
+                />
+              </div>
+            </div>
+
+            {/* Tags */}
+            <div>
+              <label className="text-xs font-medium text-gray-600 block mb-1">標籤</label>
+              <div className="flex flex-wrap gap-1 mb-1">
+                {form.tags.map(tag => (
+                  <span key={tag} className="flex items-center gap-1 bg-gray-100 text-gray-700 text-xs px-2 py-0.5 rounded">
+                    {tag}
+                    <button type="button" onClick={() => removeTag(tag)} className="text-gray-400 hover:text-red-500"><X size={10} /></button>
+                  </span>
+                ))}
+              </div>
+              <input
+                type="text"
+                value={form.tagInput}
+                onChange={e => setForm(f => ({ ...f, tagInput: e.target.value }))}
+                onKeyDown={e => {
+                  if (e.key === 'Enter') { e.preventDefault(); addTag(form.tagInput); }
+                }}
+                className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:border-indigo-500 outline-none"
+                placeholder="輸入標籤後按 Enter"
+                data-1p-ignore
+                autoComplete="off"
+              />
+            </div>
+
+            {/* Linked tasks */}
+            <div>
+              <label className="text-xs font-medium text-gray-600 block mb-1">關聯任務</label>
+              {tasks.length === 0 ? (
+                <p className="text-xs text-gray-400">此專案尚無任務可關聯</p>
+              ) : (
+                <div className="border border-gray-200 rounded-lg max-h-32 overflow-y-auto divide-y divide-gray-100">
+                  {tasks.map(task => (
+                    <label key={task.id} className="flex items-center gap-2 px-3 py-1.5 text-sm hover:bg-gray-50 cursor-pointer">
+                      <input
+                        type="checkbox"
+                        checked={form.linkedTaskIds.includes(task.id)}
+                        onChange={() => toggleTask(task.id)}
+                        className="rounded"
+                      />
+                      <span className="text-gray-700">{task.name}</span>
+                    </label>
+                  ))}
+                </div>
+              )}
+            </div>
+          </div>
+
+          {/* Buttons */}
+          <div className="border-t border-gray-100 p-3 flex justify-between items-center shrink-0 bg-white">
+            {isEdit && !showDeleteConfirm && (
+              <button
+                type="button"
+                onClick={() => setShowDeleteConfirm(true)}
+                className="text-sm text-red-500 hover:text-red-700 flex items-center gap-1"
+              >
+                <Trash2 size={14} /> 刪除
+              </button>
+            )}
+            {isEdit && showDeleteConfirm && (
+              <div className="flex items-center gap-2 text-sm">
+                <span className="text-red-600">確定刪除？</span>
+                <button type="button" onClick={() => onDelete(subProject.id)} className="text-red-600 font-bold hover:underline">是</button>
+                <button type="button" onClick={() => setShowDeleteConfirm(false)} className="text-gray-500 hover:underline">否</button>
+              </div>
+            )}
+            {!isEdit && <div />}
+            <div className="flex gap-2">
+              <button type="button" onClick={onClose} className="px-4 py-2 text-sm border border-gray-300 rounded-lg text-gray-600 hover:bg-gray-50">
+                取消
+              </button>
+              <button type="submit" className="px-4 py-2 text-sm bg-indigo-600 text-white rounded-lg font-semibold hover:bg-indigo-700 disabled:opacity-40" disabled={!form.name.trim()}>
+                {isEdit ? '儲存' : '新增'}
+              </button>
+            </div>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/src/components/SubProjectSection.jsx
+++ b/src/components/SubProjectSection.jsx
@@ -35,6 +35,11 @@ function SubProjectCard({ subProject, tasks, onEdit, onReload }) {
   const [newType, setNewType] = useState('waiting');
   const [newTitle, setNewTitle] = useState('');
   const [newWaitingOn, setNewWaitingOn] = useState('');
+  const todayLocal = () => {
+    const d = new Date();
+    return `${d.getFullYear()}-${String(d.getMonth()+1).padStart(2,'0')}-${String(d.getDate()).padStart(2,'0')}T${String(d.getHours()).padStart(2,'0')}:${String(d.getMinutes()).padStart(2,'0')}`;
+  };
+  const [newStartedAt, setNewStartedAt] = useState(todayLocal);
 
   const statusStyle = STATUS_STYLES[subProject.status] || STATUS_STYLES.active;
   const priorityStyle = PRIORITY_STYLES[subProject.priority] || PRIORITY_STYLES.medium;
@@ -68,6 +73,7 @@ function SubProjectCard({ subProject, tasks, onEdit, onReload }) {
     try {
       const payload = { type: newType, title };
       if (newType === 'waiting' && newWaitingOn.trim()) payload.waitingOn = newWaitingOn.trim();
+      if (newStartedAt) payload.startedAt = new Date(newStartedAt).toISOString();
       const created = await requestJson(`/api/sub-projects/${subProject.id}/events`, {
         method: 'POST',
         body: JSON.stringify(payload),
@@ -75,6 +81,7 @@ function SubProjectCard({ subProject, tasks, onEdit, onReload }) {
       setEvents(prev => [created, ...(prev || [])]);
       setNewTitle('');
       setNewWaitingOn('');
+      setNewStartedAt(todayLocal());
       if (newType === 'waiting') onReload();
     } catch (err) {
       console.error(err);
@@ -198,6 +205,15 @@ function SubProjectCard({ subProject, tasks, onEdit, onReload }) {
                 placeholder="在等誰？例：PM / DevOps / User"
               />
             )}
+            <div className="flex items-center gap-2">
+              <label className="text-[11px] text-gray-500 shrink-0">時間</label>
+              <input
+                type="datetime-local"
+                value={newStartedAt}
+                onChange={e => setNewStartedAt(e.target.value)}
+                className="flex-1 border border-gray-200 rounded px-2 py-1 text-xs outline-none focus:border-indigo-400"
+              />
+            </div>
             <div className="flex justify-end">
               <button
                 type="button"
@@ -278,6 +294,7 @@ function SubProjectCard({ subProject, tasks, onEdit, onReload }) {
 
 export default function SubProjectSection({
   burnupProjectId,
+  burnupProjectName,
   subProjects,
   tasks,
   onCreate,
@@ -321,7 +338,7 @@ export default function SubProjectSection({
       <div className="flex items-center justify-between mb-4">
         <div className="flex items-center gap-2">
           <MessageSquare size={18} className="text-indigo-500" />
-          <h3 className="text-base font-bold text-gray-800">Sub-projects / 工作追蹤</h3>
+          <h3 className="text-base font-bold text-gray-800">{burnupProjectName ? `${burnupProjectName} — ` : ''}Sub-projects</h3>
           <span className="text-xs text-gray-400">({projectSubProjects.length})</span>
         </div>
         <button

--- a/src/components/SubProjectSection.jsx
+++ b/src/components/SubProjectSection.jsx
@@ -1,0 +1,374 @@
+import React, { useState, useMemo, useCallback } from 'react';
+import { Plus, ChevronDown, ChevronRight, Clock, Send, CheckCircle2, Trash2, Pencil, MessageSquare, AlertCircle, FileText } from 'lucide-react';
+import { requestJson } from '../api';
+import SubProjectFormModal from './SubProjectFormModal';
+
+const STATUS_STYLES = {
+  active:    { label: '進行中', chip: 'bg-blue-50 text-blue-600 border-blue-200' },
+  paused:    { label: '暫停',   chip: 'bg-amber-50 text-amber-600 border-amber-200' },
+  done:      { label: '完成',   chip: 'bg-emerald-50 text-emerald-600 border-emerald-200' },
+  cancelled: { label: '取消',   chip: 'bg-gray-100 text-gray-500 border-gray-200' },
+};
+
+const PRIORITY_STYLES = {
+  high:   { label: '高', chip: 'bg-red-50 text-red-600' },
+  medium: { label: '中', chip: 'bg-amber-50 text-amber-600' },
+  low:    { label: '低', chip: 'bg-gray-100 text-gray-500' },
+};
+
+const EVENT_TYPE_STYLES = {
+  waiting:  { label: '等待', icon: Clock,       bg: 'bg-amber-50 border-amber-200' },
+  note:     { label: '記事', icon: FileText,    bg: 'bg-gray-50 border-gray-200' },
+  decision: { label: '決策', icon: AlertCircle, bg: 'bg-violet-50 border-violet-200' },
+};
+
+function daysBetween(isoStart, isoEnd) {
+  const start = new Date(isoStart).getTime();
+  const end = isoEnd ? new Date(isoEnd).getTime() : Date.now();
+  return Math.max(0, Math.floor((end - start) / (1000 * 60 * 60 * 24)));
+}
+
+function SubProjectCard({ subProject, tasks, onEdit, onReload }) {
+  const [expanded, setExpanded] = useState(false);
+  const [events, setEvents] = useState(null);
+  const [loading, setLoading] = useState(false);
+  const [newType, setNewType] = useState('waiting');
+  const [newTitle, setNewTitle] = useState('');
+  const [newWaitingOn, setNewWaitingOn] = useState('');
+
+  const statusStyle = STATUS_STYLES[subProject.status] || STATUS_STYLES.active;
+  const priorityStyle = PRIORITY_STYLES[subProject.priority] || PRIORITY_STYLES.medium;
+
+  const linkedTasks = useMemo(
+    () => (subProject.linkedTaskIds || []).map(id => tasks.find(t => t.id === id)).filter(Boolean),
+    [subProject.linkedTaskIds, tasks]
+  );
+
+  const loadEvents = useCallback(async () => {
+    setLoading(true);
+    try {
+      const data = await requestJson(`/api/sub-projects/${subProject.id}/events`);
+      setEvents(Array.isArray(data) ? data : []);
+    } catch {
+      setEvents([]);
+    } finally {
+      setLoading(false);
+    }
+  }, [subProject.id]);
+
+  const toggleExpand = () => {
+    const next = !expanded;
+    setExpanded(next);
+    if (next && events === null) loadEvents();
+  };
+
+  const handleAddEvent = async () => {
+    const title = newTitle.trim();
+    if (!title) return;
+    try {
+      const payload = { type: newType, title };
+      if (newType === 'waiting' && newWaitingOn.trim()) payload.waitingOn = newWaitingOn.trim();
+      const created = await requestJson(`/api/sub-projects/${subProject.id}/events`, {
+        method: 'POST',
+        body: JSON.stringify(payload),
+      });
+      setEvents(prev => [created, ...(prev || [])]);
+      setNewTitle('');
+      setNewWaitingOn('');
+      if (newType === 'waiting') onReload();
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  const handleResolve = async (event) => {
+    try {
+      const now = new Date().toISOString();
+      const updated = await requestJson(`/api/events/${event.id}`, {
+        method: 'PATCH',
+        body: JSON.stringify({ resolvedAt: now }),
+      });
+      setEvents(prev => (prev || []).map(e => e.id === event.id ? updated : e));
+      onReload();
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  const handleDeleteEvent = async (event) => {
+    if (!window.confirm('確定刪除此事件？')) return;
+    try {
+      await requestJson(`/api/events/${event.id}`, { method: 'DELETE' });
+      setEvents(prev => (prev || []).filter(e => e.id !== event.id));
+      if (event.type === 'waiting' && !event.resolvedAt) onReload();
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  return (
+    <div className={`border rounded-lg bg-white shadow-sm overflow-hidden ${statusStyle.chip.includes('gray') ? 'opacity-75' : ''}`}>
+      {/* Card header */}
+      <div className="flex items-start gap-2 p-3">
+        <button
+          onClick={toggleExpand}
+          className="text-gray-400 hover:text-gray-600 mt-0.5 shrink-0"
+          title={expanded ? '收合' : '展開 timeline'}
+        >
+          {expanded ? <ChevronDown size={18} /> : <ChevronRight size={18} />}
+        </button>
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 flex-wrap">
+            <h4 className="font-semibold text-gray-800 text-sm truncate">{subProject.name}</h4>
+            <span className={`text-[11px] px-1.5 py-0.5 rounded border ${statusStyle.chip}`}>
+              {statusStyle.label}
+            </span>
+            <span className={`text-[11px] px-1.5 py-0.5 rounded ${priorityStyle.chip}`}>
+              {priorityStyle.label}
+            </span>
+            {subProject.activeWaitingCount > 0 && (
+              <span className="text-[11px] px-1.5 py-0.5 rounded bg-amber-100 text-amber-700 font-semibold flex items-center gap-0.5">
+                <Clock size={10} /> {subProject.activeWaitingCount}
+              </span>
+            )}
+          </div>
+          {subProject.description && (
+            <p className="text-xs text-gray-500 mt-0.5 truncate">{subProject.description}</p>
+          )}
+          <div className="flex items-center gap-3 mt-1 text-xs text-gray-500">
+            {subProject.owner && <span>👤 {subProject.owner}</span>}
+            {subProject.dueDate && <span>📅 {subProject.dueDate}</span>}
+            {linkedTasks.length > 0 && (
+              <span>🔗 {linkedTasks.map(t => t.name).join(', ')}</span>
+            )}
+          </div>
+          {subProject.tags && subProject.tags.length > 0 && (
+            <div className="flex gap-1 flex-wrap mt-1">
+              {subProject.tags.map(t => (
+                <span key={t} className="text-[10px] bg-gray-100 text-gray-600 px-1.5 py-0.5 rounded">{t}</span>
+              ))}
+            </div>
+          )}
+        </div>
+        <button
+          onClick={() => onEdit(subProject)}
+          className="text-gray-400 hover:text-indigo-600 p-1 shrink-0"
+          title="編輯"
+        >
+          <Pencil size={14} />
+        </button>
+      </div>
+
+      {/* Timeline + add form */}
+      {expanded && (
+        <div className="border-t border-gray-100 p-3 bg-gray-50 space-y-3">
+          {/* Add event form */}
+          <div className="bg-white border border-gray-200 rounded-lg p-2 space-y-2">
+            <div className="flex gap-1">
+              {Object.entries(EVENT_TYPE_STYLES).map(([value, { label, icon: Icon }]) => (
+                <button
+                  key={value}
+                  type="button"
+                  onClick={() => setNewType(value)}
+                  className={`flex items-center gap-1 text-xs px-2 py-1 rounded border transition ${
+                    newType === value
+                      ? 'bg-indigo-50 border-indigo-300 text-indigo-700'
+                      : 'bg-white border-gray-200 text-gray-500 hover:border-gray-300'
+                  }`}
+                >
+                  <Icon size={11} /> {label}
+                </button>
+              ))}
+            </div>
+            <input
+              type="text"
+              value={newTitle}
+              onChange={e => setNewTitle(e.target.value)}
+              onKeyDown={e => { if (e.key === 'Enter') { e.preventDefault(); handleAddEvent(); } }}
+              className="w-full border border-gray-200 rounded px-2 py-1 text-sm outline-none focus:border-indigo-400"
+              placeholder={newType === 'waiting' ? '在等什麼？' : newType === 'decision' ? '做了什麼決策？' : '記一下'}
+            />
+            {newType === 'waiting' && (
+              <input
+                type="text"
+                value={newWaitingOn}
+                onChange={e => setNewWaitingOn(e.target.value)}
+                onKeyDown={e => { if (e.key === 'Enter') { e.preventDefault(); handleAddEvent(); } }}
+                className="w-full border border-gray-200 rounded px-2 py-1 text-sm outline-none focus:border-indigo-400"
+                placeholder="在等誰？例：PM / DevOps / User"
+              />
+            )}
+            <div className="flex justify-end">
+              <button
+                type="button"
+                onClick={handleAddEvent}
+                disabled={!newTitle.trim()}
+                className="flex items-center gap-1 text-xs text-indigo-600 hover:text-indigo-800 disabled:text-gray-300 font-semibold px-2 py-1"
+              >
+                <Send size={12} /> 新增事件
+              </button>
+            </div>
+          </div>
+
+          {/* Timeline */}
+          {loading && <p className="text-xs text-gray-400 text-center py-2">載入中...</p>}
+          {!loading && events && events.length === 0 && (
+            <p className="text-xs text-gray-400 text-center py-2">尚無事件</p>
+          )}
+          {!loading && events && events.length > 0 && (
+            <div className="space-y-2">
+              {events.map(event => {
+                const style = EVENT_TYPE_STYLES[event.type] || EVENT_TYPE_STYLES.note;
+                const Icon = style.icon;
+                const isActive = event.type === 'waiting' && !event.resolvedAt;
+                const days = daysBetween(event.startedAt, event.resolvedAt);
+                return (
+                  <div key={event.id} className={`border rounded-lg p-2 text-sm ${style.bg} group`}>
+                    <div className="flex items-start gap-2">
+                      <Icon size={14} className="mt-0.5 shrink-0 text-gray-600" />
+                      <div className="flex-1 min-w-0">
+                        <div className="flex items-center gap-2 flex-wrap">
+                          <span className="font-medium text-gray-800">{event.title}</span>
+                          {event.type === 'waiting' && event.waitingOn && (
+                            <span className="text-[11px] bg-white text-gray-600 px-1.5 py-0.5 rounded border">
+                              在等 {event.waitingOn}
+                            </span>
+                          )}
+                          {isActive && (
+                            <span className="text-[11px] text-amber-700 font-semibold">已卡 {days} 天</span>
+                          )}
+                          {!isActive && event.type === 'waiting' && (
+                            <span className="text-[11px] text-gray-500">共卡 {days} 天 ✓</span>
+                          )}
+                        </div>
+                        {event.body && <p className="text-xs text-gray-600 mt-0.5">{event.body}</p>}
+                        <p className="text-[10px] text-gray-400 mt-1">
+                          {new Date(event.startedAt).toLocaleString('zh-TW')}
+                        </p>
+                      </div>
+                      <div className="flex items-center gap-0.5 opacity-0 group-hover:opacity-100 transition shrink-0">
+                        {isActive && (
+                          <button
+                            onClick={() => handleResolve(event)}
+                            className="text-emerald-500 hover:text-emerald-700 p-1"
+                            title="標記為已解除"
+                          >
+                            <CheckCircle2 size={14} />
+                          </button>
+                        )}
+                        <button
+                          onClick={() => handleDeleteEvent(event)}
+                          className="text-gray-400 hover:text-red-500 p-1"
+                          title="刪除"
+                        >
+                          <Trash2 size={12} />
+                        </button>
+                      </div>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default function SubProjectSection({
+  burnupProjectId,
+  subProjects,
+  tasks,
+  onCreate,
+  onUpdate,
+  onDelete,
+  onReload,
+}) {
+  const [showFormModal, setShowFormModal] = useState(false);
+  const [editing, setEditing] = useState(null);
+  const [showDoneCancelled, setShowDoneCancelled] = useState(false);
+
+  const projectSubProjects = useMemo(
+    () => subProjects.filter(sp => sp.burnupProjectId === burnupProjectId),
+    [subProjects, burnupProjectId]
+  );
+
+  const activeOnes = projectSubProjects.filter(sp => sp.status !== 'done' && sp.status !== 'cancelled');
+  const doneOnes = projectSubProjects.filter(sp => sp.status === 'done' || sp.status === 'cancelled');
+
+  const openCreate = () => { setEditing(null); setShowFormModal(true); };
+  const openEdit = (sp) => { setEditing(sp); setShowFormModal(true); };
+
+  const handleSave = async (data) => {
+    if (data.id) {
+      await onUpdate(data.id, data);
+    } else {
+      await onCreate(burnupProjectId, data);
+    }
+    setShowFormModal(false);
+    setEditing(null);
+  };
+
+  const handleDelete = async (id) => {
+    await onDelete(id);
+    setShowFormModal(false);
+    setEditing(null);
+  };
+
+  return (
+    <div className="bg-white rounded-xl p-5 border border-gray-200 shadow-sm mt-6">
+      <div className="flex items-center justify-between mb-4">
+        <div className="flex items-center gap-2">
+          <MessageSquare size={18} className="text-indigo-500" />
+          <h3 className="text-base font-bold text-gray-800">Sub-projects / 工作追蹤</h3>
+          <span className="text-xs text-gray-400">({projectSubProjects.length})</span>
+        </div>
+        <button
+          onClick={openCreate}
+          className="flex items-center gap-1 px-3 py-1.5 text-sm bg-indigo-600 text-white rounded-lg font-semibold hover:bg-indigo-700 transition"
+        >
+          <Plus size={14} /> 新增 Sub-project
+        </button>
+      </div>
+
+      {projectSubProjects.length === 0 ? (
+        <p className="text-sm text-gray-400 text-center py-6">尚無 sub-project，點右上角新增</p>
+      ) : (
+        <div className="space-y-2">
+          {activeOnes.map(sp => (
+            <SubProjectCard key={sp.id} subProject={sp} tasks={tasks} onEdit={openEdit} onReload={onReload} />
+          ))}
+          {doneOnes.length > 0 && (
+            <div>
+              <button
+                onClick={() => setShowDoneCancelled(v => !v)}
+                className="text-xs text-gray-400 hover:text-gray-600 flex items-center gap-1 mt-2"
+              >
+                {showDoneCancelled ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
+                已完成 / 已取消 ({doneOnes.length})
+              </button>
+              {showDoneCancelled && (
+                <div className="space-y-2 mt-2">
+                  {doneOnes.map(sp => (
+                    <SubProjectCard key={sp.id} subProject={sp} tasks={tasks} onEdit={openEdit} onReload={onReload} />
+                  ))}
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+      )}
+
+      {showFormModal && (
+        <SubProjectFormModal
+          subProject={editing}
+          tasks={tasks}
+          onSave={handleSave}
+          onDelete={handleDelete}
+          onClose={() => { setShowFormModal(false); setEditing(null); }}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/components/TodoBoard.jsx
+++ b/src/components/TodoBoard.jsx
@@ -53,8 +53,10 @@ export default function TodoBoard({
   const editingTodo = useMemo(() => editingTodoId ? todos.find(t => t.id === editingTodoId) || null : null, [editingTodoId, todos]);
 
   useEffect(() => {
-    if (initialEditTodoId && onClearInitialEditTodoId) {
-      onClearInitialEditTodoId();
+    if (initialEditTodoId) {
+      setEditingTodoId(initialEditTodoId);
+      setShowFormModal(true);
+      if (onClearInitialEditTodoId) onClearInitialEditTodoId();
     }
   }, [initialEditTodoId, onClearInitialEditTodoId]);
 

--- a/src/components/TodoBoard.jsx
+++ b/src/components/TodoBoard.jsx
@@ -29,7 +29,7 @@ export default function TodoBoard({
   // Edit panel variant: 'drawer' (default) | 'modal', persisted in localStorage
   const [editVariant, setEditVariant] = useState(() => {
     const saved = typeof window !== 'undefined' ? localStorage.getItem('todoEditVariant') : null;
-    return saved === 'modal' || saved === 'drawer' ? saved : 'drawer';
+    return saved === 'modal' || saved === 'drawer' ? saved : 'modal';
   });
   useEffect(() => {
     localStorage.setItem('todoEditVariant', editVariant);

--- a/src/components/TodoBoard.jsx
+++ b/src/components/TodoBoard.jsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useEffect, useCallback } from 'react';
+import { useState, useMemo, useEffect, useCallback, useRef } from 'react';
 import { Plus, EyeOff, Eye, Filter, X, GripVertical, Play, Flag, ArrowUpDown, PanelRight, Square } from 'lucide-react';
 import TodoCard from './TodoCard';
 import TodoFormModal from './TodoFormModal';
@@ -12,6 +12,7 @@ export default function TodoBoard({
 }) {
   const [editingTodoId, setEditingTodoId] = useState(initialEditTodoId || null);
   const [showFormModal, setShowFormModal] = useState(!!initialEditTodoId);
+  const prevInitialEditTodoIdRef = useRef(initialEditTodoId);
   const [_draggingId, setDraggingId] = useState(null);
   const [dragOverColumn, setDragOverColumn] = useState(null);
   const [hideDone, setHideDone] = useState(false);
@@ -52,13 +53,12 @@ export default function TodoBoard({
 
   const editingTodo = useMemo(() => editingTodoId ? todos.find(t => t.id === editingTodoId) || null : null, [editingTodoId, todos]);
 
-  useEffect(() => {
-    if (initialEditTodoId) {
-      setEditingTodoId(initialEditTodoId);
-      setShowFormModal(true);
-      if (onClearInitialEditTodoId) onClearInitialEditTodoId();
-    }
-  }, [initialEditTodoId, onClearInitialEditTodoId]);
+  if (initialEditTodoId && initialEditTodoId !== prevInitialEditTodoIdRef.current) {
+    prevInitialEditTodoIdRef.current = initialEditTodoId;
+    setEditingTodoId(initialEditTodoId);
+    setShowFormModal(true);
+    if (onClearInitialEditTodoId) onClearInitialEditTodoId();
+  }
 
   const allTags = useMemo(() => {
     const tagSet = new Set();

--- a/src/components/TodoBoard.jsx
+++ b/src/components/TodoBoard.jsx
@@ -4,7 +4,7 @@ import TodoCard from './TodoCard';
 import TodoFormModal from './TodoFormModal';
 
 export default function TodoBoard({
-  todos, statuses, allTasks, projects,
+  todos, statuses, allTasks, projects, subProjects = [],
   onCreateTodo, onUpdateTodo, onDeleteTodo,
   onCreateStatus, onUpdateStatus, onDeleteStatus, onReorderStatuses,
   onCreateComment, onUpdateComment, onDeleteComment,
@@ -20,6 +20,7 @@ export default function TodoBoard({
   const [filterAssignees, setFilterAssignees] = useState(new Set());
   const [filterPriorities, setFilterPriorities] = useState(new Set());
   const [filterTags, setFilterTags] = useState(new Set());
+  const [filterSubProjectId, setFilterSubProjectId] = useState('');
   const [showFilters, setShowFilters] = useState(false);
 
   // Sort: null | 'priority-desc' | 'priority-asc' | 'dueDate-asc' | 'dueDate-desc'
@@ -74,9 +75,16 @@ export default function TodoBoard({
       if (filterAssignees.size > 0 && !filterAssignees.has(t.assignee || '')) return false;
       if (filterPriorities.size > 0 && !filterPriorities.has(t.priority)) return false;
       if (filterTags.size > 0 && !(t.tags || []).some(tag => filterTags.has(tag))) return false;
+      if (filterSubProjectId && (t.subProjectId || '') !== filterSubProjectId) return false;
       return true;
     });
-  }, [todos, filterAssignees, filterPriorities, filterTags]);
+  }, [todos, filterAssignees, filterPriorities, filterTags, filterSubProjectId]);
+
+  const subProjectById = useMemo(() => {
+    const map = new Map();
+    subProjects.forEach(sp => map.set(sp.id, sp));
+    return map;
+  }, [subProjects]);
 
   const columnTodos = useMemo(() => {
     const PRIORITY_ORDER = { high: 0, medium: 1, low: 2 };
@@ -232,7 +240,7 @@ export default function TodoBoard({
     setEditingTodoId(null);
   };
 
-  const hasActiveFilters = filterAssignees.size > 0 || filterPriorities.size > 0 || filterTags.size > 0;
+  const hasActiveFilters = filterAssignees.size > 0 || filterPriorities.size > 0 || filterTags.size > 0 || !!filterSubProjectId;
   const endStatus = statuses.find(s => s.isDefaultEnd);
   const endStatusName = endStatus ? endStatus.name : '已完成';
 
@@ -255,12 +263,25 @@ export default function TodoBoard({
           </button>
           {hasActiveFilters && (
             <button
-              onClick={() => { setFilterAssignees(new Set()); setFilterPriorities(new Set()); setFilterTags(new Set()); }}
+              onClick={() => { setFilterAssignees(new Set()); setFilterPriorities(new Set()); setFilterTags(new Set()); setFilterSubProjectId(''); }}
               className="text-xs text-gray-400 hover:text-gray-600"
             >
               清除篩選
             </button>
           )}
+          <select
+            value={filterSubProjectId}
+            onChange={e => setFilterSubProjectId(e.target.value)}
+            className={`text-xs px-2 py-1.5 border rounded-lg outline-none ${filterSubProjectId ? 'border-violet-300 text-violet-700 bg-violet-50' : 'border-gray-200 text-gray-500'}`}
+            title="篩選 sub-project"
+          >
+            <option value="">所有 sub-project</option>
+            {subProjects.map(sp => {
+              const proj = projects.find(p => p.id === sp.burnupProjectId);
+              const label = proj ? `${proj.name} / ${sp.name}` : sp.name;
+              return <option key={sp.id} value={sp.id}>{label}</option>;
+            })}
+          </select>
           <span className="w-px h-5 bg-gray-200" />
           {/* Sort buttons */}
           <button
@@ -436,6 +457,7 @@ export default function TodoBoard({
                       onDragStart={setDraggingId}
                       onDragEnd={() => { setDraggingId(null); setDragOverColumn(null); }}
                       allTasks={allTasks}
+                      subProject={todo.subProjectId ? subProjectById.get(todo.subProjectId) : null}
                     />
                   ))
                 )}
@@ -466,6 +488,7 @@ export default function TodoBoard({
           projects={projects}
           allTags={allTags}
           allAssignees={allAssignees}
+          subProjects={subProjects}
           onSave={handleSave}
           onDelete={handleDelete}
           onClose={() => { setShowFormModal(false); setEditingTodoId(null); }}

--- a/src/components/TodoBoard.jsx
+++ b/src/components/TodoBoard.jsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useEffect, useCallback, useRef } from 'react';
+import { useState, useMemo, useEffect, useCallback } from 'react';
 import { Plus, EyeOff, Eye, Filter, X, GripVertical, Play, Flag, ArrowUpDown, PanelRight, Square } from 'lucide-react';
 import TodoCard from './TodoCard';
 import TodoFormModal from './TodoFormModal';
@@ -12,7 +12,7 @@ export default function TodoBoard({
 }) {
   const [editingTodoId, setEditingTodoId] = useState(initialEditTodoId || null);
   const [showFormModal, setShowFormModal] = useState(!!initialEditTodoId);
-  const prevInitialEditTodoIdRef = useRef(initialEditTodoId);
+  const [prevInitialEditTodoId, setPrevInitialEditTodoId] = useState(initialEditTodoId);
   const [_draggingId, setDraggingId] = useState(null);
   const [dragOverColumn, setDragOverColumn] = useState(null);
   const [hideDone, setHideDone] = useState(false);
@@ -53,8 +53,8 @@ export default function TodoBoard({
 
   const editingTodo = useMemo(() => editingTodoId ? todos.find(t => t.id === editingTodoId) || null : null, [editingTodoId, todos]);
 
-  if (initialEditTodoId && initialEditTodoId !== prevInitialEditTodoIdRef.current) {
-    prevInitialEditTodoIdRef.current = initialEditTodoId;
+  if (initialEditTodoId && initialEditTodoId !== prevInitialEditTodoId) {
+    setPrevInitialEditTodoId(initialEditTodoId);
     setEditingTodoId(initialEditTodoId);
     setShowFormModal(true);
     if (onClearInitialEditTodoId) onClearInitialEditTodoId();

--- a/src/components/TodoCard.jsx
+++ b/src/components/TodoCard.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Calendar, MessageSquare } from 'lucide-react';
+import { assigneeColor } from '../utils/assigneeColor';
 
 const PRIORITY_STYLES = {
   high: { border: 'border-l-red-500', badge: 'bg-red-50 text-red-600' },
@@ -8,29 +9,6 @@ const PRIORITY_STYLES = {
 };
 
 const PRIORITY_LABELS = { high: '高', medium: '中', low: '低' };
-
-const ASSIGNEE_COLORS = [
-  'bg-rose-400',
-  'bg-orange-400',
-  'bg-amber-400',
-  'bg-lime-500',
-  'bg-emerald-500',
-  'bg-teal-500',
-  'bg-cyan-500',
-  'bg-sky-500',
-  'bg-indigo-400',
-  'bg-violet-500',
-  'bg-fuchsia-500',
-  'bg-pink-500',
-];
-
-function assigneeColor(name) {
-  let hash = 0;
-  for (let i = 0; i < name.length; i++) {
-    hash = (hash * 31 + name.charCodeAt(i)) | 0;
-  }
-  return ASSIGNEE_COLORS[Math.abs(hash) % ASSIGNEE_COLORS.length];
-}
 
 export default function TodoCard({ todo, isDone, onEdit, onDragStart, onDragEnd, allTasks, subProject }) {
   const ps = PRIORITY_STYLES[todo.priority] || PRIORITY_STYLES.medium;

--- a/src/components/TodoCard.jsx
+++ b/src/components/TodoCard.jsx
@@ -32,7 +32,7 @@ function assigneeColor(name) {
   return ASSIGNEE_COLORS[Math.abs(hash) % ASSIGNEE_COLORS.length];
 }
 
-export default function TodoCard({ todo, isDone, onEdit, onDragStart, onDragEnd, allTasks }) {
+export default function TodoCard({ todo, isDone, onEdit, onDragStart, onDragEnd, allTasks, subProject }) {
   const ps = PRIORITY_STYLES[todo.priority] || PRIORITY_STYLES.medium;
 
   const linkedTask = todo.linkedTaskId
@@ -67,8 +67,13 @@ export default function TodoCard({ todo, isDone, onEdit, onDragStart, onDragEnd,
         </span>
       </div>
 
-      {/* Linked Task */}
-      <div className="text-xs text-gray-500 mb-2">
+      {/* Sub-project + Linked Task */}
+      <div className="text-xs text-gray-500 mb-2 flex items-center gap-1.5 flex-wrap">
+        {subProject && (
+          <span className="bg-violet-50 text-violet-700 px-1.5 py-0.5 rounded text-[11px] font-medium">
+            {subProject.name}
+          </span>
+        )}
         {linkedTask ? (
           <span className="text-indigo-500">🔗 {linkedTask.name}</span>
         ) : todo.linkedTaskId ? (

--- a/src/components/TodoFormModal.jsx
+++ b/src/components/TodoFormModal.jsx
@@ -132,19 +132,19 @@ export default function TodoFormModal({ todo, statuses, allTasks: _allTasks, pro
         className={
           isDrawer
             ? `fixed right-0 top-0 h-full w-[480px] max-w-full bg-white shadow-2xl flex flex-col transform transition-transform duration-300 ease-out ${mounted ? 'translate-x-0' : 'translate-x-full'}`
-            : 'bg-white rounded-xl shadow-2xl w-full max-w-md overflow-hidden'
+            : 'bg-white rounded-xl shadow-2xl w-full max-w-md max-h-[85vh] flex flex-col overflow-hidden'
         }
         onClick={e => e.stopPropagation()}
       >
-        <div className={`flex justify-between items-center p-4 border-b border-gray-100 ${isDrawer ? 'shrink-0' : ''}`}>
+        <div className="flex justify-between items-center p-4 border-b border-gray-100 shrink-0">
           <h3 className="text-base font-bold text-gray-800">{isEdit ? '編輯 Todo' : '新增 Todo'}</h3>
           <button onClick={onClose} className="p-1 rounded-full hover:bg-gray-100 text-gray-400 hover:text-gray-600">
             <X size={20} />
           </button>
         </div>
 
-        <form onSubmit={handleSubmit} className={isDrawer ? 'flex-1 flex flex-col min-h-0' : ''}>
-          <div className={isDrawer ? 'flex-1 overflow-y-auto p-4 space-y-3' : 'p-4 space-y-3'}>
+        <form onSubmit={handleSubmit} className="flex-1 flex flex-col min-h-0">
+          <div className="flex-1 overflow-y-auto p-4 space-y-3">
           {/* Title */}
           <div>
             <label className="text-xs font-medium text-gray-600 block mb-1">標題 *</label>
@@ -370,10 +370,7 @@ export default function TodoFormModal({ todo, statuses, allTasks: _allTasks, pro
           </div>
 
           {/* Buttons */}
-          <div className={isDrawer
-            ? 'border-t border-gray-100 p-3 flex justify-between items-center shrink-0 bg-white'
-            : 'flex justify-between items-center px-4 pb-4 pt-2'
-          }>
+          <div className="border-t border-gray-100 p-3 flex justify-between items-center shrink-0 bg-white">
             {isEdit && !showDeleteConfirm && (
               <button
                 type="button"

--- a/src/components/TodoFormModal.jsx
+++ b/src/components/TodoFormModal.jsx
@@ -24,7 +24,7 @@ function renderCommentContent(text) {
   });
 }
 
-export default function TodoFormModal({ todo, statuses, allTasks: _allTasks, projects, allTags, allAssignees, onSave, onDelete, onClose, onCreateComment, onUpdateComment, onDeleteComment, variant = 'modal' }) {
+export default function TodoFormModal({ todo, statuses, allTasks: _allTasks, projects, allTags, allAssignees, subProjects = [], onSave, onDelete, onClose, onCreateComment, onUpdateComment, onDeleteComment, variant = 'modal' }) {
   const isDrawer = variant === 'drawer';
   const isEdit = !!todo;
   const startStatus = statuses.find(s => s.isDefaultStart);
@@ -39,6 +39,7 @@ export default function TodoFormModal({ todo, statuses, allTasks: _allTasks, pro
     tagInput: '',
     note: todo?.note || '',
     linkedTaskId: todo?.linkedTaskId || '',
+    subProjectId: todo?.subProjectId || '',
   }), [todo, startStatus]);
 
   const [form, setForm] = useState(initialForm);
@@ -117,6 +118,7 @@ export default function TodoFormModal({ todo, statuses, allTasks: _allTasks, pro
       tags: finalTags,
       note: form.note || null,
       linkedTaskId: form.linkedTaskId || null,
+      subProjectId: form.subProjectId || '',
     });
   };
 
@@ -250,6 +252,23 @@ export default function TodoFormModal({ todo, statuses, allTasks: _allTasks, pro
             <datalist id="tag-suggestions">
               {tagSuggestions.map(t => <option key={t} value={t} />)}
             </datalist>
+          </div>
+
+          {/* Sub-project */}
+          <div>
+            <label className="text-xs font-medium text-gray-600 block mb-1">所屬 Sub-project</label>
+            <select
+              value={form.subProjectId}
+              onChange={e => setForm(f => ({ ...f, subProjectId: e.target.value }))}
+              className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:border-indigo-500 outline-none"
+            >
+              <option value="">無</option>
+              {subProjects.map(sp => {
+                const proj = projects.find(p => p.id === sp.burnupProjectId);
+                const label = proj ? `${proj.name} / ${sp.name}` : sp.name;
+                return <option key={sp.id} value={sp.id}>{label}</option>;
+              })}
+            </select>
           </div>
 
           {/* Linked Task */}

--- a/src/utils/assigneeColor.js
+++ b/src/utils/assigneeColor.js
@@ -1,0 +1,22 @@
+const ASSIGNEE_COLORS = [
+  'bg-rose-400',
+  'bg-orange-400',
+  'bg-amber-400',
+  'bg-lime-500',
+  'bg-emerald-500',
+  'bg-teal-500',
+  'bg-cyan-500',
+  'bg-sky-500',
+  'bg-indigo-400',
+  'bg-violet-500',
+  'bg-fuchsia-500',
+  'bg-pink-500',
+];
+
+export function assigneeColor(name) {
+  let hash = 0;
+  for (let i = 0; i < name.length; i++) {
+    hash = (hash * 31 + name.charCodeAt(i)) | 0;
+  }
+  return ASSIGNEE_COLORS[Math.abs(hash) % ASSIGNEE_COLORS.length];
+}


### PR DESCRIPTION
## Summary

Adds a **sub-project** entity (parallel to tasks under each burnup project) so the team can track smaller work packages through their lifecycle — especially the "waiting" states that dominate real projects (waiting for PM, DevOps, user decisions).

### Data model
- New tables: \`sub_projects\`, \`sub_project_tasks\` (0..N task link), \`sub_project_events\` (polymorphic parent: sub_project or todo)
- New column: \`todos.sub_project_id\` (nullable)
- Events have \`type\` (waiting/note/decision), \`waiting_on\`, \`started_at\`, \`resolved_at\` so blockers can be counted and time-tracked

### Backend
- New router \`backend/routers/sub_projects.py\` with CRUD + event endpoints
- \`backend/routers/todos.py\` validates and persists \`subProjectId\`
- 9 new pytest cases covering CRUD, task link, events, parent validation, todo link, cascade delete

### Frontend
- \`SubProjectSection\` mounted under each burnup project view — list of sub-project cards with expandable timeline, inline add-event form, mark-as-resolved, active waiting count badge
- \`SubProjectFormModal\` for create/edit with status, owner, due date, priority, tags, linked tasks
- \`TodoFormModal\` gains a sub-project selector
- \`TodoBoard\` toolbar adds a sub-project filter
- \`TodoCard\` shows a violet chip with the sub-project name when assigned

## Test plan

- [ ] \`poetry run pytest\` — 77 tests green
- [ ] \`npx vitest run\` — 41 tests green
- [ ] \`npm run build\` succeeds
- [ ] Manual: create a sub-project under Yield Data with linked tasks
- [ ] Manual: add a waiting event, verify "已卡 N 天" counter + waiting badge on card
- [ ] Manual: mark as resolved, verify badge decrements
- [ ] Manual: create todo assigned to sub-project, verify chip on TodoCard and filter works
- [ ] Manual: delete sub-project, verify linked todos have \`subProjectId\` cleared (not deleted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)