### PR TITLE
Opt-in Next UI redesign + Time log + unified activity feed

### DIFF
--- a/backend/db.py
+++ b/backend/db.py
@@ -149,6 +149,17 @@ def init_db() -> None:
             );
             CREATE INDEX IF NOT EXISTS idx_sub_project_events_parent ON sub_project_events(parent_type, parent_id);
             CREATE INDEX IF NOT EXISTS idx_sub_project_events_active ON sub_project_events(type, resolved_at);
+            CREATE TABLE IF NOT EXISTS time_entries (
+                id TEXT PRIMARY KEY,
+                user_id TEXT NOT NULL,
+                item TEXT NOT NULL,
+                hours REAL NOT NULL,
+                date TEXT NOT NULL,
+                note TEXT,
+                created_at TEXT NOT NULL,
+                FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+            );
+            CREATE INDEX IF NOT EXISTS idx_time_entries_user_date ON time_entries(user_id, date);
             """
         )
         # Seed default statuses if table is empty

--- a/backend/main.py
+++ b/backend/main.py
@@ -6,7 +6,17 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from auth import cleanup_expired_tokens
 from db import init_db
-from routers import auth_routes, logs, projects, statuses, sub_projects, tasks, todos
+from routers import (
+    activity,
+    auth_routes,
+    logs,
+    projects,
+    statuses,
+    sub_projects,
+    tasks,
+    time_entries,
+    todos,
+)
 
 app = FastAPI(title="Burnup Chart API")
 
@@ -33,6 +43,8 @@ app.include_router(logs.router)
 app.include_router(statuses.router)
 app.include_router(todos.router)
 app.include_router(sub_projects.router)
+app.include_router(activity.router)
+app.include_router(time_entries.router)
 
 
 @app.on_event("startup")

--- a/backend/models.py
+++ b/backend/models.py
@@ -5,9 +5,37 @@ from typing import Any, Dict, List, Optional
 from pydantic import BaseModel, Field
 
 # Type aliases
-LogPayload = Dict[str, str]
+LogPayload = Dict[str, Any]
 TaskPayload = Dict[str, Any]
 ProjectPayload = Dict[str, Any]
+
+
+# ---------------------------------------------------------------------------
+# Time-entry models (per-user work-time log)
+# ---------------------------------------------------------------------------
+
+
+class TimeEntryCreate(BaseModel):
+    item: str
+    hours: float = Field(gt=0)
+    date: str  # YYYY-MM-DD
+    note: Optional[str] = None
+
+
+class TimeEntryUpdate(BaseModel):
+    item: Optional[str] = None
+    hours: Optional[float] = Field(default=None, gt=0)
+    date: Optional[str] = None
+    note: Optional[str] = None
+
+
+class TimeEntryOut(BaseModel):
+    id: str
+    item: str
+    hours: float
+    date: str
+    note: Optional[str] = None
+    createdAt: str
 
 
 # ---------------------------------------------------------------------------
@@ -25,6 +53,7 @@ class LogOut(BaseModel):
     id: str
     date: str
     content: str
+    author: Optional[str] = None
 
 
 # ---------------------------------------------------------------------------
@@ -174,6 +203,7 @@ class TodoCommentOut(BaseModel):
     content: str
     createdAt: str
     updatedAt: str
+    author: Optional[str] = None
 
 
 class TodoOut(BaseModel):

--- a/backend/routers/activity.py
+++ b/backend/routers/activity.py
@@ -58,14 +58,16 @@ def list_activity(
             (project_id, limit),
         ).fetchall()
         for r in log_rows:
-            items.append(ActivityItem(
-                id=f"log:{r['id']}",
-                kind="log",
-                who=r["who"],
-                when=r["when_ts"],
-                text=r["text"],
-                context=r["context"],
-            ))
+            items.append(
+                ActivityItem(
+                    id=f"log:{r['id']}",
+                    kind="log",
+                    who=r["who"],
+                    when=r["when_ts"],
+                    text=r["text"],
+                    context=r["context"],
+                )
+            )
 
         # Todo comments: todo must be linked either to a task in this project
         # OR to a sub-project under this burnup project.
@@ -89,14 +91,16 @@ def list_activity(
             (project_id, project_id, limit),
         ).fetchall()
         for r in comment_rows:
-            items.append(ActivityItem(
-                id=f"comment:{r['id']}",
-                kind="comment",
-                who=r["who"],
-                when=r["when_ts"],
-                text=r["text"],
-                context=r["context"],
-            ))
+            items.append(
+                ActivityItem(
+                    id=f"comment:{r['id']}",
+                    kind="comment",
+                    who=r["who"],
+                    when=r["when_ts"],
+                    text=r["text"],
+                    context=r["context"],
+                )
+            )
 
         # Sub-project events (parent_type = 'sub_project') for sub-projects
         # belonging to this burnup project. Also surface events attached to
@@ -142,15 +146,17 @@ def list_activity(
             if r["body"]:
                 text_parts.append(r["body"])
             text = " · ".join(text_parts) if text_parts else ""
-            items.append(ActivityItem(
-                id=f"event:{r['id']}",
-                kind=kind,
-                who=r["who"],
-                when=r["when_ts"],
-                text=text,
-                context=r["context"],
-                waitingOn=r["waiting_on"] if kind == "waiting" else None,
-            ))
+            items.append(
+                ActivityItem(
+                    id=f"event:{r['id']}",
+                    kind=kind,
+                    who=r["who"],
+                    when=r["when_ts"],
+                    text=text,
+                    context=r["context"],
+                    waitingOn=r["waiting_on"] if kind == "waiting" else None,
+                )
+            )
 
     # Global sort across all sources, newest first, then apply limit.
     items.sort(key=lambda it: it.when or "", reverse=True)

--- a/backend/routers/activity.py
+++ b/backend/routers/activity.py
@@ -1,0 +1,157 @@
+"""Unified activity feed.
+
+Merges task logs, todo comments, and sub-project events for a given
+burnup project into a single time-ordered list. Powers the Activity
+rail on the new Burnup dashboard.
+"""
+
+from typing import List, Literal, Optional
+
+from fastapi import APIRouter, Depends, Query
+from pydantic import BaseModel
+
+from auth import get_current_user
+from db import get_connection
+
+router = APIRouter(prefix="/api", tags=["activity"])
+
+
+ActivityKind = Literal["log", "comment", "waiting", "decision", "note"]
+
+
+class ActivityItem(BaseModel):
+    id: str
+    kind: ActivityKind
+    who: Optional[str] = None
+    when: str
+    text: str
+    context: Optional[str] = None
+    waitingOn: Optional[str] = None
+
+
+@router.get("/activity", response_model=List[ActivityItem])
+def list_activity(
+    project_id: str = Query(..., alias="project_id"),
+    limit: int = Query(50, ge=1, le=200),
+    _current_user: dict = Depends(get_current_user),
+) -> List[ActivityItem]:
+    """Return merged activity for a burnup project, newest first."""
+    items: List[ActivityItem] = []
+
+    with get_connection() as conn:
+        # Task logs
+        log_rows = conn.execute(
+            """
+            SELECT
+                l.id            AS id,
+                l.content       AS text,
+                l.created_at    AS when_ts,
+                t.name          AS context,
+                COALESCE(u.display_name, u.username) AS who
+            FROM logs l
+            JOIN tasks t ON t.id = l.task_id
+            LEFT JOIN users u ON u.id = l.author_id
+            WHERE t.project_id = ?
+            ORDER BY l.created_at DESC
+            LIMIT ?
+            """,
+            (project_id, limit),
+        ).fetchall()
+        for r in log_rows:
+            items.append(ActivityItem(
+                id=f"log:{r['id']}",
+                kind="log",
+                who=r["who"],
+                when=r["when_ts"],
+                text=r["text"],
+                context=r["context"],
+            ))
+
+        # Todo comments: todo must be linked either to a task in this project
+        # OR to a sub-project under this burnup project.
+        comment_rows = conn.execute(
+            """
+            SELECT
+                c.id            AS id,
+                c.content       AS text,
+                c.created_at    AS when_ts,
+                td.title        AS context,
+                COALESCE(u.display_name, u.username) AS who
+            FROM todo_comments c
+            JOIN todos td       ON td.id = c.todo_id
+            LEFT JOIN tasks t   ON t.id = td.linked_task_id
+            LEFT JOIN sub_projects sp ON sp.id = td.sub_project_id
+            LEFT JOIN users u   ON u.id = c.author_id
+            WHERE t.project_id = ? OR sp.burnup_project_id = ?
+            ORDER BY c.created_at DESC
+            LIMIT ?
+            """,
+            (project_id, project_id, limit),
+        ).fetchall()
+        for r in comment_rows:
+            items.append(ActivityItem(
+                id=f"comment:{r['id']}",
+                kind="comment",
+                who=r["who"],
+                when=r["when_ts"],
+                text=r["text"],
+                context=r["context"],
+            ))
+
+        # Sub-project events (parent_type = 'sub_project') for sub-projects
+        # belonging to this burnup project. Also surface events attached to
+        # todos that belong to the project.
+        event_rows = conn.execute(
+            """
+            SELECT
+                e.id            AS id,
+                e.type          AS kind,
+                e.title         AS title,
+                e.body          AS body,
+                e.waiting_on    AS waiting_on,
+                e.started_at    AS when_ts,
+                CASE
+                    WHEN e.parent_type = 'sub_project' THEN sp_direct.name
+                    WHEN e.parent_type = 'todo'        THEN td.title
+                END AS context,
+                COALESCE(u.display_name, u.username) AS who
+            FROM sub_project_events e
+            LEFT JOIN sub_projects sp_direct
+                ON e.parent_type = 'sub_project' AND sp_direct.id = e.parent_id
+            LEFT JOIN todos td
+                ON e.parent_type = 'todo' AND td.id = e.parent_id
+            LEFT JOIN tasks t_via_todo
+                ON td.linked_task_id = t_via_todo.id
+            LEFT JOIN sub_projects sp_via_todo
+                ON td.sub_project_id = sp_via_todo.id
+            LEFT JOIN users u ON u.id = e.created_by
+            WHERE (e.parent_type = 'sub_project' AND sp_direct.burnup_project_id = ?)
+               OR (e.parent_type = 'todo' AND (t_via_todo.project_id = ? OR sp_via_todo.burnup_project_id = ?))
+            ORDER BY e.started_at DESC
+            LIMIT ?
+            """,
+            (project_id, project_id, project_id, limit),
+        ).fetchall()
+        for r in event_rows:
+            kind = r["kind"]
+            if kind not in ("waiting", "decision", "note"):
+                continue
+            text_parts = []
+            if r["title"]:
+                text_parts.append(r["title"])
+            if r["body"]:
+                text_parts.append(r["body"])
+            text = " · ".join(text_parts) if text_parts else ""
+            items.append(ActivityItem(
+                id=f"event:{r['id']}",
+                kind=kind,
+                who=r["who"],
+                when=r["when_ts"],
+                text=text,
+                context=r["context"],
+                waitingOn=r["waiting_on"] if kind == "waiting" else None,
+            ))
+
+    # Global sort across all sources, newest first, then apply limit.
+    items.sort(key=lambda it: it.when or "", reverse=True)
+    return items[:limit]

--- a/backend/routers/logs.py
+++ b/backend/routers/logs.py
@@ -27,9 +27,7 @@ def row_to_log(row: sqlite3.Row) -> LogPayload:
     }
 
 
-def _fetch_log_with_author(
-    conn: sqlite3.Connection, log_id: str
-) -> sqlite3.Row:
+def _fetch_log_with_author(conn: sqlite3.Connection, log_id: str) -> sqlite3.Row:
     return conn.execute(
         """SELECT l.*, COALESCE(u.display_name, u.username) AS author_name
            FROM logs l

--- a/backend/routers/logs.py
+++ b/backend/routers/logs.py
@@ -14,7 +14,29 @@ router = APIRouter(prefix="/api", tags=["logs"])
 
 
 def row_to_log(row: sqlite3.Row) -> LogPayload:
-    return {"id": row["id"], "date": row["date"], "content": row["content"]}
+    author = None
+    try:
+        author = row["author_name"]
+    except (IndexError, KeyError):
+        author = None
+    return {
+        "id": row["id"],
+        "date": row["date"],
+        "content": row["content"],
+        "author": author,
+    }
+
+
+def _fetch_log_with_author(
+    conn: sqlite3.Connection, log_id: str
+) -> sqlite3.Row:
+    return conn.execute(
+        """SELECT l.*, COALESCE(u.display_name, u.username) AS author_name
+           FROM logs l
+           LEFT JOIN users u ON u.id = l.author_id
+           WHERE l.id = ?""",
+        (log_id,),
+    ).fetchone()
 
 
 def utc_now() -> str:
@@ -29,7 +51,7 @@ def utc_now() -> str:
 def create_log(
     task_id: str,
     payload: LogCreate,
-    _current_user: dict = Depends(require_member_or_admin),
+    current_user: dict = Depends(require_member_or_admin),
 ) -> LogPayload:
     log_id = payload.id or f"log_{uuid4().hex}"
     now = utc_now()
@@ -46,13 +68,13 @@ def create_log(
             raise HTTPException(status_code=409, detail="Log id already exists")
 
         conn.execute(
-            "INSERT INTO logs (id, task_id, date, content, created_at) "
-            "VALUES (?, ?, ?, ?, ?)",
-            (log_id, task_id, payload.date, payload.content, now),
+            "INSERT INTO logs (id, task_id, date, content, created_at, author_id) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            (log_id, task_id, payload.date, payload.content, now, current_user["id"]),
         )
         conn.commit()
 
-        log_row = conn.execute("SELECT * FROM logs WHERE id = ?", (log_id,)).fetchone()
+        log_row = _fetch_log_with_author(conn, log_id)
 
     return row_to_log(log_row)
 

--- a/backend/routers/projects.py
+++ b/backend/routers/projects.py
@@ -64,7 +64,11 @@ def fetch_project(
     if task_ids:
         placeholders = ",".join("?" for _ in task_ids)
         log_rows = conn.execute(
-            f"SELECT * FROM logs WHERE task_id IN ({placeholders}) ORDER BY created_at",
+            f"""SELECT l.*, COALESCE(u.display_name, u.username) AS author_name
+                FROM logs l
+                LEFT JOIN users u ON u.id = l.author_id
+                WHERE l.task_id IN ({placeholders})
+                ORDER BY l.created_at""",
             task_ids,
         ).fetchall()
         for row in log_rows:
@@ -90,7 +94,12 @@ def list_projects(
             "SELECT id, name FROM projects ORDER BY created_at"
         ).fetchall()
         task_rows = conn.execute("SELECT * FROM tasks ORDER BY created_at").fetchall()
-        log_rows = conn.execute("SELECT * FROM logs ORDER BY created_at").fetchall()
+        log_rows = conn.execute(
+            """SELECT l.*, COALESCE(u.display_name, u.username) AS author_name
+               FROM logs l
+               LEFT JOIN users u ON u.id = l.author_id
+               ORDER BY l.created_at"""
+        ).fetchall()
 
     logs_by_task: Dict[str, List[LogPayload]] = {}
     for row in log_rows:

--- a/backend/routers/tasks.py
+++ b/backend/routers/tasks.py
@@ -17,7 +17,17 @@ def normalize_text(value: Optional[str]) -> str:
 
 
 def row_to_log(row: sqlite3.Row) -> LogPayload:
-    return {"id": row["id"], "date": row["date"], "content": row["content"]}
+    author = None
+    try:
+        author = row["author_name"]
+    except (IndexError, KeyError):
+        author = None
+    return {
+        "id": row["id"],
+        "date": row["date"],
+        "content": row["content"],
+        "author": author,
+    }
 
 
 def row_to_task(row: sqlite3.Row, logs: List[LogPayload]) -> TaskPayload:
@@ -42,7 +52,12 @@ def fetch_task(conn: sqlite3.Connection, task_id: str) -> Optional[TaskPayload]:
     if not task_row:
         return None
     log_rows = conn.execute(
-        "SELECT * FROM logs WHERE task_id = ? ORDER BY created_at", (task_id,)
+        """SELECT l.*, COALESCE(u.display_name, u.username) AS author_name
+           FROM logs l
+           LEFT JOIN users u ON u.id = l.author_id
+           WHERE l.task_id = ?
+           ORDER BY l.created_at""",
+        (task_id,),
     ).fetchall()
     logs = [row_to_log(row) for row in log_rows]
     return row_to_task(task_row, logs)

--- a/backend/routers/time_entries.py
+++ b/backend/routers/time_entries.py
@@ -1,0 +1,303 @@
+"""Personal time-log endpoints.
+
+Lets authenticated users record how many hours they spent on a
+free-text "item" on a given day, and query aggregated summaries
+grouped by day / week / month.
+"""
+
+import sqlite3
+from datetime import datetime, timedelta
+from typing import Any, Dict, List, Optional
+from uuid import uuid4
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+
+from auth import get_current_user
+from db import get_connection
+from models import TimeEntryCreate, TimeEntryOut, TimeEntryUpdate
+
+router = APIRouter(prefix="/api", tags=["time-entries"])
+
+
+def utc_now() -> str:
+    return datetime.utcnow().isoformat()
+
+
+DATE_RE = r"^\d{4}-\d{2}-\d{2}$"
+
+
+def _validate_date(value: str, label: str = "date") -> None:
+    import re
+    if not re.match(DATE_RE, value):
+        raise HTTPException(
+            status_code=400, detail=f"{label} must be YYYY-MM-DD"
+        )
+
+
+def _round_quarter(hours: float) -> float:
+    """Snap hours to 0.25-hour precision."""
+    return round(hours * 4) / 4
+
+
+def row_to_entry(row: sqlite3.Row) -> Dict[str, Any]:
+    return {
+        "id": row["id"],
+        "item": row["item"],
+        "hours": row["hours"],
+        "date": row["date"],
+        "note": row["note"],
+        "createdAt": row["created_at"],
+    }
+
+
+@router.get("/time-entries", response_model=List[TimeEntryOut])
+def list_time_entries(
+    from_: Optional[str] = Query(default=None, alias="from"),
+    to: Optional[str] = Query(default=None),
+    current_user: dict = Depends(get_current_user),
+) -> List[Dict[str, Any]]:
+    if from_:
+        _validate_date(from_, "from")
+    if to:
+        _validate_date(to, "to")
+
+    clauses = ["user_id = ?"]
+    params: List[Any] = [current_user["id"]]
+    if from_:
+        clauses.append("date >= ?")
+        params.append(from_)
+    if to:
+        clauses.append("date <= ?")
+        params.append(to)
+
+    where = " AND ".join(clauses)
+    with get_connection() as conn:
+        rows = conn.execute(
+            f"SELECT * FROM time_entries WHERE {where} ORDER BY date DESC, created_at DESC",
+            params,
+        ).fetchall()
+    return [row_to_entry(r) for r in rows]
+
+
+@router.post(
+    "/time-entries",
+    response_model=TimeEntryOut,
+    status_code=status.HTTP_201_CREATED,
+)
+def create_time_entry(
+    payload: TimeEntryCreate,
+    current_user: dict = Depends(get_current_user),
+) -> Dict[str, Any]:
+    _validate_date(payload.date)
+    item = payload.item.strip()
+    if not item:
+        raise HTTPException(status_code=400, detail="item must not be empty")
+    hours = _round_quarter(payload.hours)
+    if hours <= 0:
+        raise HTTPException(status_code=400, detail="hours must be > 0")
+
+    entry_id = f"te_{uuid4().hex}"
+    now = utc_now()
+    with get_connection() as conn:
+        conn.execute(
+            """INSERT INTO time_entries (id, user_id, item, hours, date, note, created_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?)""",
+            (entry_id, current_user["id"], item, hours, payload.date, payload.note, now),
+        )
+        conn.commit()
+        row = conn.execute(
+            "SELECT * FROM time_entries WHERE id = ?", (entry_id,)
+        ).fetchone()
+    return row_to_entry(row)
+
+
+@router.patch("/time-entries/{entry_id}", response_model=TimeEntryOut)
+def update_time_entry(
+    entry_id: str,
+    payload: TimeEntryUpdate,
+    current_user: dict = Depends(get_current_user),
+) -> Dict[str, Any]:
+    fields: List[str] = []
+    values: List[Any] = []
+    if payload.item is not None:
+        item = payload.item.strip()
+        if not item:
+            raise HTTPException(status_code=400, detail="item must not be empty")
+        fields.append("item = ?")
+        values.append(item)
+    if payload.hours is not None:
+        hours = _round_quarter(payload.hours)
+        if hours <= 0:
+            raise HTTPException(status_code=400, detail="hours must be > 0")
+        fields.append("hours = ?")
+        values.append(hours)
+    if payload.date is not None:
+        _validate_date(payload.date)
+        fields.append("date = ?")
+        values.append(payload.date)
+    if payload.note is not None:
+        fields.append("note = ?")
+        values.append(payload.note)
+
+    with get_connection() as conn:
+        existing = conn.execute(
+            "SELECT * FROM time_entries WHERE id = ? AND user_id = ?",
+            (entry_id, current_user["id"]),
+        ).fetchone()
+        if not existing:
+            raise HTTPException(status_code=404, detail="Time entry not found")
+        if fields:
+            values.append(entry_id)
+            values.append(current_user["id"])
+            conn.execute(
+                f"UPDATE time_entries SET {', '.join(fields)} WHERE id = ? AND user_id = ?",
+                values,
+            )
+            conn.commit()
+        row = conn.execute(
+            "SELECT * FROM time_entries WHERE id = ?", (entry_id,)
+        ).fetchone()
+    return row_to_entry(row)
+
+
+@router.delete("/time-entries/{entry_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_time_entry(
+    entry_id: str,
+    current_user: dict = Depends(get_current_user),
+) -> None:
+    with get_connection() as conn:
+        result = conn.execute(
+            "DELETE FROM time_entries WHERE id = ? AND user_id = ?",
+            (entry_id, current_user["id"]),
+        )
+        conn.commit()
+    if result.rowcount == 0:
+        raise HTTPException(status_code=404, detail="Time entry not found")
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Summary aggregation: hours per item, grouped by day / week / month.
+# ---------------------------------------------------------------------------
+
+
+def _iso_week_start(date_str: str) -> str:
+    """Return the Monday of the ISO week containing date_str, as YYYY-MM-DD."""
+    d = datetime.strptime(date_str, "%Y-%m-%d").date()
+    monday = d - timedelta(days=d.weekday())
+    return monday.isoformat()
+
+
+def _month_start(date_str: str) -> str:
+    """Return the first day of the month containing date_str."""
+    return date_str[:7] + "-01"
+
+
+def _bucket(date_str: str, period: str) -> str:
+    if period == "day":
+        return date_str
+    if period == "week":
+        return _iso_week_start(date_str)
+    if period == "month":
+        return _month_start(date_str)
+    raise HTTPException(
+        status_code=400, detail="period must be one of: day, week, month"
+    )
+
+
+@router.get("/time-entries/summary")
+def time_entry_summary(
+    period: str = Query("day"),
+    from_: Optional[str] = Query(default=None, alias="from"),
+    to: Optional[str] = Query(default=None),
+    current_user: dict = Depends(get_current_user),
+) -> Dict[str, Any]:
+    """Return aggregated hours grouped by {period, item}.
+
+    Response shape:
+      {
+        "period": "day",
+        "buckets": [
+          {
+            "key": "2026-04-19",
+            "total": 7.5,
+            "items": [
+              {"item": "API refactor", "hours": 4.0, "percent": 53.3},
+              {"item": "Meeting",       "hours": 3.5, "percent": 46.7}
+            ]
+          },
+          ...
+        ],
+        "overall": {
+          "total": 37.5,
+          "items": [
+            {"item": "API refactor", "hours": 18.0, "percent": 48.0},
+            ...
+          ]
+        }
+      }
+    """
+    if period not in ("day", "week", "month"):
+        raise HTTPException(
+            status_code=400, detail="period must be one of: day, week, month"
+        )
+    if from_:
+        _validate_date(from_, "from")
+    if to:
+        _validate_date(to, "to")
+
+    clauses = ["user_id = ?"]
+    params: List[Any] = [current_user["id"]]
+    if from_:
+        clauses.append("date >= ?")
+        params.append(from_)
+    if to:
+        clauses.append("date <= ?")
+        params.append(to)
+    where = " AND ".join(clauses)
+
+    with get_connection() as conn:
+        rows = conn.execute(
+            f"SELECT date, item, hours FROM time_entries WHERE {where}",
+            params,
+        ).fetchall()
+
+    bucket_map: Dict[str, Dict[str, float]] = {}
+    overall_items: Dict[str, float] = {}
+
+    for r in rows:
+        key = _bucket(r["date"], period)
+        items = bucket_map.setdefault(key, {})
+        items[r["item"]] = items.get(r["item"], 0.0) + r["hours"]
+        overall_items[r["item"]] = overall_items.get(r["item"], 0.0) + r["hours"]
+
+    def items_with_percent(items: Dict[str, float]) -> List[Dict[str, Any]]:
+        total = sum(items.values()) or 1.0
+        out = [
+            {
+                "item": name,
+                "hours": round(hours, 2),
+                "percent": round((hours / total) * 100, 1),
+            }
+            for name, hours in items.items()
+        ]
+        out.sort(key=lambda x: (-x["hours"], x["item"]))
+        return out
+
+    buckets = []
+    for key in sorted(bucket_map.keys(), reverse=True):
+        items = bucket_map[key]
+        buckets.append({
+            "key": key,
+            "total": round(sum(items.values()), 2),
+            "items": items_with_percent(items),
+        })
+
+    return {
+        "period": period,
+        "buckets": buckets,
+        "overall": {
+            "total": round(sum(overall_items.values()), 2),
+            "items": items_with_percent(overall_items),
+        },
+    }

--- a/backend/routers/time_entries.py
+++ b/backend/routers/time_entries.py
@@ -28,10 +28,9 @@ DATE_RE = r"^\d{4}-\d{2}-\d{2}$"
 
 def _validate_date(value: str, label: str = "date") -> None:
     import re
+
     if not re.match(DATE_RE, value):
-        raise HTTPException(
-            status_code=400, detail=f"{label} must be YYYY-MM-DD"
-        )
+        raise HTTPException(status_code=400, detail=f"{label} must be YYYY-MM-DD")
 
 
 def _round_quarter(hours: float) -> float:
@@ -102,7 +101,15 @@ def create_time_entry(
         conn.execute(
             """INSERT INTO time_entries (id, user_id, item, hours, date, note, created_at)
                VALUES (?, ?, ?, ?, ?, ?, ?)""",
-            (entry_id, current_user["id"], item, hours, payload.date, payload.note, now),
+            (
+                entry_id,
+                current_user["id"],
+                item,
+                hours,
+                payload.date,
+                payload.note,
+                now,
+            ),
         )
         conn.commit()
         row = conn.execute(
@@ -287,11 +294,13 @@ def time_entry_summary(
     buckets = []
     for key in sorted(bucket_map.keys(), reverse=True):
         items = bucket_map[key]
-        buckets.append({
-            "key": key,
-            "total": round(sum(items.values()), 2),
-            "items": items_with_percent(items),
-        })
+        buckets.append(
+            {
+                "key": key,
+                "total": round(sum(items.values()), 2),
+                "items": items_with_percent(items),
+            }
+        )
 
     return {
         "period": period,

--- a/backend/routers/todos.py
+++ b/backend/routers/todos.py
@@ -28,12 +28,20 @@ def normalize_text(value: Optional[str]) -> str:
 
 
 def row_to_todo_comment(row: sqlite3.Row) -> Dict[str, Any]:
+    # Row may come from a plain `todo_comments` SELECT (no author name) or a
+    # JOIN-enriched row that exposes an `author_name` column.
+    author = None
+    try:
+        author = row["author_name"]
+    except (IndexError, KeyError):
+        author = None
     return {
         "id": row["id"],
         "todoId": row["todo_id"],
         "content": row["content"],
         "createdAt": row["created_at"],
         "updatedAt": row["updated_at"],
+        "author": author,
     }
 
 
@@ -64,13 +72,29 @@ def _fetch_todo_comments(
         return {}
     placeholders = ",".join("?" * len(todo_ids))
     rows = conn.execute(
-        f"SELECT * FROM todo_comments WHERE todo_id IN ({placeholders}) ORDER BY created_at",
+        f"""SELECT c.*, COALESCE(u.display_name, u.username) AS author_name
+            FROM todo_comments c
+            LEFT JOIN users u ON u.id = c.author_id
+            WHERE c.todo_id IN ({placeholders})
+            ORDER BY c.created_at""",
         todo_ids,
     ).fetchall()
     result: Dict[str, List[Dict[str, Any]]] = {}
     for row in rows:
         result.setdefault(row["todo_id"], []).append(row_to_todo_comment(row))
     return result
+
+
+def _fetch_comment_with_author(
+    conn: sqlite3.Connection, comment_id: str
+) -> Optional[sqlite3.Row]:
+    return conn.execute(
+        """SELECT c.*, COALESCE(u.display_name, u.username) AS author_name
+           FROM todo_comments c
+           LEFT JOIN users u ON u.id = c.author_id
+           WHERE c.id = ?""",
+        (comment_id,),
+    ).fetchone()
 
 
 def utc_now() -> str:
@@ -215,11 +239,8 @@ def update_todo(
             conn.commit()
 
         row = conn.execute("SELECT * FROM todos WHERE id = ?", (todo_id,)).fetchone()
-        comments = conn.execute(
-            "SELECT * FROM todo_comments WHERE todo_id = ? ORDER BY created_at",
-            (todo_id,),
-        ).fetchall()
-    return row_to_todo(row, [row_to_todo_comment(c) for c in comments])
+        comments_map = _fetch_todo_comments(conn, [todo_id])
+    return row_to_todo(row, comments_map.get(todo_id, []))
 
 
 @router.delete("/todos/{todo_id}", status_code=status.HTTP_204_NO_CONTENT)
@@ -263,7 +284,7 @@ def list_task_todos(
 def create_todo_comment(
     todo_id: str,
     payload: TodoCommentCreate,
-    _current_user: dict = Depends(require_member_or_admin),
+    current_user: dict = Depends(require_member_or_admin),
 ) -> Dict[str, Any]:
     comment_id = f"tc_{uuid4().hex}"
     now = utc_now()
@@ -274,13 +295,11 @@ def create_todo_comment(
         if not todo_row:
             raise HTTPException(status_code=404, detail="Todo not found")
         conn.execute(
-            "INSERT INTO todo_comments (id, todo_id, content, created_at, updated_at) VALUES (?, ?, ?, ?, ?)",
-            (comment_id, todo_id, payload.content, now, now),
+            "INSERT INTO todo_comments (id, todo_id, content, created_at, updated_at, author_id) VALUES (?, ?, ?, ?, ?, ?)",
+            (comment_id, todo_id, payload.content, now, now, current_user["id"]),
         )
         conn.commit()
-        row = conn.execute(
-            "SELECT * FROM todo_comments WHERE id = ?", (comment_id,)
-        ).fetchone()
+        row = _fetch_comment_with_author(conn, comment_id)
     return row_to_todo_comment(row)
 
 
@@ -302,9 +321,7 @@ def update_todo_comment(
             (payload.content, now, comment_id),
         )
         conn.commit()
-        row = conn.execute(
-            "SELECT * FROM todo_comments WHERE id = ?", (comment_id,)
-        ).fetchone()
+        row = _fetch_comment_with_author(conn, comment_id)
     return row_to_todo_comment(row)
 
 

--- a/backend/tests/test_activity.py
+++ b/backend/tests/test_activity.py
@@ -1,0 +1,229 @@
+"""Tests for the unified /api/activity endpoint."""
+
+import sys
+from pathlib import Path
+from typing import Any, Dict, Generator
+
+import pytest
+from fastapi.testclient import TestClient
+
+BASE_DIR = Path(__file__).resolve().parents[1]
+if str(BASE_DIR) not in sys.path:
+    sys.path.insert(0, str(BASE_DIR))
+
+import db
+import main
+
+
+def _auth_headers(client: TestClient) -> Dict[str, str]:
+    resp = client.post(
+        "/api/auth/bootstrap",
+        json={"username": "testadmin", "password": "testpass123"},
+    )
+    assert resp.status_code == 200
+    return {"Authorization": f"Bearer {resp.json()['access_token']}"}
+
+
+@pytest.fixture()
+def client(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> Generator[TestClient, None, None]:
+    db_path = tmp_path / "test.sqlite3"
+    monkeypatch.setattr(db, "DB_PATH", db_path)
+    with TestClient(main.app) as c:
+        yield c
+
+
+@pytest.fixture()
+def auth(client: TestClient) -> Dict[str, str]:
+    return _auth_headers(client)
+
+
+def _mk_project(client: TestClient, auth: Dict[str, str], name: str) -> Dict[str, Any]:
+    r = client.post("/api/projects", json={"name": name}, headers=auth)
+    assert r.status_code == 201
+    return r.json()
+
+
+def _mk_task(client: TestClient, auth: Dict[str, str], project_id: str, name: str) -> Dict[str, Any]:
+    r = client.post(
+        f"/api/projects/{project_id}/tasks",
+        json={
+            "name": name, "points": 3, "people": "Alice",
+            "addedDate": "2026-04-01", "expectedStart": "2026-04-01",
+            "expectedEnd": "2026-04-05",
+        },
+        headers=auth,
+    )
+    assert r.status_code == 201, r.text
+    return r.json()
+
+
+def _mk_log(client: TestClient, auth: Dict[str, str], task_id: str, content: str) -> Dict[str, Any]:
+    r = client.post(
+        f"/api/tasks/{task_id}/logs",
+        json={"date": "2026-04-10", "content": content},
+        headers=auth,
+    )
+    assert r.status_code == 201
+    return r.json()
+
+
+def _mk_todo(client: TestClient, auth: Dict[str, str], title: str, **kw: Any) -> Dict[str, Any]:
+    payload = {"title": title, **kw}
+    r = client.post("/api/todos", json=payload, headers=auth)
+    assert r.status_code == 201, r.text
+    return r.json()
+
+
+def _mk_comment(client: TestClient, auth: Dict[str, str], todo_id: str, content: str) -> Dict[str, Any]:
+    r = client.post(
+        f"/api/todos/{todo_id}/comments",
+        json={"content": content},
+        headers=auth,
+    )
+    assert r.status_code == 201
+    return r.json()
+
+
+def _mk_sub_project(client: TestClient, auth: Dict[str, str], project_id: str, name: str) -> Dict[str, Any]:
+    r = client.post(
+        f"/api/projects/{project_id}/sub-projects",
+        json={"name": name, "priority": "medium"},
+        headers=auth,
+    )
+    assert r.status_code == 201, r.text
+    return r.json()
+
+
+def _mk_event(client: TestClient, auth: Dict[str, str], sp_id: str, event_type: str, title: str, **kw: Any) -> Dict[str, Any]:
+    payload = {"type": event_type, "title": title, **kw}
+    r = client.post(
+        f"/api/sub-projects/{sp_id}/events",
+        json=payload,
+        headers=auth,
+    )
+    assert r.status_code == 201, r.text
+    return r.json()
+
+
+def test_activity_unauthenticated_returns_401(client: TestClient) -> None:
+    r = client.get("/api/activity?project_id=anything")
+    assert r.status_code == 401
+
+
+def test_activity_requires_project_id(client: TestClient, auth: Dict[str, str]) -> None:
+    r = client.get("/api/activity", headers=auth)
+    assert r.status_code == 422
+
+
+def test_activity_empty_project_returns_empty(client: TestClient, auth: Dict[str, str]) -> None:
+    project = _mk_project(client, auth, "Empty proj")
+    r = client.get(f"/api/activity?project_id={project['id']}", headers=auth)
+    assert r.status_code == 200
+    assert r.json() == []
+
+
+def test_activity_returns_task_logs(client: TestClient, auth: Dict[str, str]) -> None:
+    project = _mk_project(client, auth, "Alpha")
+    task = _mk_task(client, auth, project["id"], "Design schema")
+    _mk_log(client, auth, task["id"], "Drafted v1")
+    _mk_log(client, auth, task["id"], "Review done")
+
+    r = client.get(f"/api/activity?project_id={project['id']}", headers=auth)
+    assert r.status_code == 200
+    items = r.json()
+    assert len(items) == 2
+    assert {it["kind"] for it in items} == {"log"}
+    assert {it["context"] for it in items} == {"Design schema"}
+    # logs don't currently record author_id — `who` may be None; just
+    # assert the field is present.
+    for it in items:
+        assert "who" in it
+    # newest first
+    assert items[0]["when"] >= items[1]["when"]
+
+
+def test_activity_returns_todo_comments_linked_to_task(
+    client: TestClient, auth: Dict[str, str]
+) -> None:
+    project = _mk_project(client, auth, "WithTodos")
+    task = _mk_task(client, auth, project["id"], "Impl foo")
+    todo = _mk_todo(client, auth, "Implement foo", linkedTaskId=task["id"])
+    _mk_comment(client, auth, todo["id"], "Note on foo")
+
+    r = client.get(f"/api/activity?project_id={project['id']}", headers=auth)
+    assert r.status_code == 200
+    items = r.json()
+    kinds = [it["kind"] for it in items]
+    assert "comment" in kinds
+    comment = next(it for it in items if it["kind"] == "comment")
+    assert comment["text"] == "Note on foo"
+    assert comment["context"] == "Implement foo"
+
+
+def test_activity_returns_sub_project_events(
+    client: TestClient, auth: Dict[str, str]
+) -> None:
+    project = _mk_project(client, auth, "Proj")
+    sp = _mk_sub_project(client, auth, project["id"], "SP")
+    _mk_event(client, auth, sp["id"], "waiting", "block on PM", waitingOn="PM")
+    _mk_event(client, auth, sp["id"], "decision", "use JWT")
+    _mk_event(client, auth, sp["id"], "note", "kickoff done")
+
+    r = client.get(f"/api/activity?project_id={project['id']}", headers=auth)
+    assert r.status_code == 200
+    items = r.json()
+    kinds = {it["kind"] for it in items}
+    assert kinds == {"waiting", "decision", "note"}
+    waiting = next(it for it in items if it["kind"] == "waiting")
+    assert waiting["waitingOn"] == "PM"
+    assert waiting["context"] == "SP"
+
+
+def test_activity_merges_all_sources_sorted_desc(
+    client: TestClient, auth: Dict[str, str]
+) -> None:
+    project = _mk_project(client, auth, "Merged")
+    task = _mk_task(client, auth, project["id"], "T1")
+    todo = _mk_todo(client, auth, "TD1", linkedTaskId=task["id"])
+    sp = _mk_sub_project(client, auth, project["id"], "SP")
+
+    _mk_log(client, auth, task["id"], "log entry")
+    _mk_comment(client, auth, todo["id"], "comment entry")
+    _mk_event(client, auth, sp["id"], "note", "event entry")
+
+    r = client.get(f"/api/activity?project_id={project['id']}", headers=auth)
+    items = r.json()
+    assert len(items) == 3
+    assert {it["kind"] for it in items} == {"log", "comment", "note"}
+    # sorted desc by when
+    whens = [it["when"] for it in items]
+    assert whens == sorted(whens, reverse=True)
+
+
+def test_activity_isolates_other_projects(
+    client: TestClient, auth: Dict[str, str]
+) -> None:
+    p1 = _mk_project(client, auth, "P1")
+    p2 = _mk_project(client, auth, "P2")
+    t1 = _mk_task(client, auth, p1["id"], "T1")
+    t2 = _mk_task(client, auth, p2["id"], "T2")
+    _mk_log(client, auth, t1["id"], "p1 log")
+    _mk_log(client, auth, t2["id"], "p2 log")
+
+    r = client.get(f"/api/activity?project_id={p1['id']}", headers=auth)
+    items = r.json()
+    assert len(items) == 1
+    assert items[0]["text"] == "p1 log"
+
+
+def test_activity_respects_limit(client: TestClient, auth: Dict[str, str]) -> None:
+    project = _mk_project(client, auth, "Many")
+    task = _mk_task(client, auth, project["id"], "T")
+    for i in range(6):
+        _mk_log(client, auth, task["id"], f"log #{i}")
+
+    r = client.get(f"/api/activity?project_id={project['id']}&limit=3", headers=auth)
+    items = r.json()
+    assert len(items) == 3

--- a/backend/tests/test_activity.py
+++ b/backend/tests/test_activity.py
@@ -45,12 +45,17 @@ def _mk_project(client: TestClient, auth: Dict[str, str], name: str) -> Dict[str
     return r.json()
 
 
-def _mk_task(client: TestClient, auth: Dict[str, str], project_id: str, name: str) -> Dict[str, Any]:
+def _mk_task(
+    client: TestClient, auth: Dict[str, str], project_id: str, name: str
+) -> Dict[str, Any]:
     r = client.post(
         f"/api/projects/{project_id}/tasks",
         json={
-            "name": name, "points": 3, "people": "Alice",
-            "addedDate": "2026-04-01", "expectedStart": "2026-04-01",
+            "name": name,
+            "points": 3,
+            "people": "Alice",
+            "addedDate": "2026-04-01",
+            "expectedStart": "2026-04-01",
             "expectedEnd": "2026-04-05",
         },
         headers=auth,
@@ -59,7 +64,9 @@ def _mk_task(client: TestClient, auth: Dict[str, str], project_id: str, name: st
     return r.json()
 
 
-def _mk_log(client: TestClient, auth: Dict[str, str], task_id: str, content: str) -> Dict[str, Any]:
+def _mk_log(
+    client: TestClient, auth: Dict[str, str], task_id: str, content: str
+) -> Dict[str, Any]:
     r = client.post(
         f"/api/tasks/{task_id}/logs",
         json={"date": "2026-04-10", "content": content},
@@ -69,14 +76,18 @@ def _mk_log(client: TestClient, auth: Dict[str, str], task_id: str, content: str
     return r.json()
 
 
-def _mk_todo(client: TestClient, auth: Dict[str, str], title: str, **kw: Any) -> Dict[str, Any]:
+def _mk_todo(
+    client: TestClient, auth: Dict[str, str], title: str, **kw: Any
+) -> Dict[str, Any]:
     payload = {"title": title, **kw}
     r = client.post("/api/todos", json=payload, headers=auth)
     assert r.status_code == 201, r.text
     return r.json()
 
 
-def _mk_comment(client: TestClient, auth: Dict[str, str], todo_id: str, content: str) -> Dict[str, Any]:
+def _mk_comment(
+    client: TestClient, auth: Dict[str, str], todo_id: str, content: str
+) -> Dict[str, Any]:
     r = client.post(
         f"/api/todos/{todo_id}/comments",
         json={"content": content},
@@ -86,7 +97,9 @@ def _mk_comment(client: TestClient, auth: Dict[str, str], todo_id: str, content:
     return r.json()
 
 
-def _mk_sub_project(client: TestClient, auth: Dict[str, str], project_id: str, name: str) -> Dict[str, Any]:
+def _mk_sub_project(
+    client: TestClient, auth: Dict[str, str], project_id: str, name: str
+) -> Dict[str, Any]:
     r = client.post(
         f"/api/projects/{project_id}/sub-projects",
         json={"name": name, "priority": "medium"},
@@ -96,7 +109,14 @@ def _mk_sub_project(client: TestClient, auth: Dict[str, str], project_id: str, n
     return r.json()
 
 
-def _mk_event(client: TestClient, auth: Dict[str, str], sp_id: str, event_type: str, title: str, **kw: Any) -> Dict[str, Any]:
+def _mk_event(
+    client: TestClient,
+    auth: Dict[str, str],
+    sp_id: str,
+    event_type: str,
+    title: str,
+    **kw: Any,
+) -> Dict[str, Any]:
     payload = {"type": event_type, "title": title, **kw}
     r = client.post(
         f"/api/sub-projects/{sp_id}/events",
@@ -117,7 +137,9 @@ def test_activity_requires_project_id(client: TestClient, auth: Dict[str, str]) 
     assert r.status_code == 422
 
 
-def test_activity_empty_project_returns_empty(client: TestClient, auth: Dict[str, str]) -> None:
+def test_activity_empty_project_returns_empty(
+    client: TestClient, auth: Dict[str, str]
+) -> None:
     project = _mk_project(client, auth, "Empty proj")
     r = client.get(f"/api/activity?project_id={project['id']}", headers=auth)
     assert r.status_code == 200

--- a/backend/tests/test_time_entries.py
+++ b/backend/tests/test_time_entries.py
@@ -70,7 +70,9 @@ def test_hours_snap_to_quarter(client: TestClient, auth: Dict[str, str]) -> None
     assert e2["hours"] == 2.75
 
 
-def test_zero_or_negative_hours_rejected(client: TestClient, auth: Dict[str, str]) -> None:
+def test_zero_or_negative_hours_rejected(
+    client: TestClient, auth: Dict[str, str]
+) -> None:
     r = client.post(
         "/api/time-entries",
         json={"item": "x", "hours": 0, "date": "2026-04-19"},

--- a/backend/tests/test_time_entries.py
+++ b/backend/tests/test_time_entries.py
@@ -1,0 +1,222 @@
+"""Tests for the per-user time-log endpoints."""
+
+import sys
+from pathlib import Path
+from typing import Any, Dict, Generator
+
+import pytest
+from fastapi.testclient import TestClient
+
+BASE_DIR = Path(__file__).resolve().parents[1]
+if str(BASE_DIR) not in sys.path:
+    sys.path.insert(0, str(BASE_DIR))
+
+import db
+import main
+
+
+def _auth_headers(client: TestClient) -> Dict[str, str]:
+    resp = client.post(
+        "/api/auth/bootstrap",
+        json={"username": "timeadmin", "password": "testpass123"},
+    )
+    assert resp.status_code == 200
+    return {"Authorization": f"Bearer {resp.json()['access_token']}"}
+
+
+@pytest.fixture()
+def client(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> Generator[TestClient, None, None]:
+    db_path = tmp_path / "test.sqlite3"
+    monkeypatch.setattr(db, "DB_PATH", db_path)
+    with TestClient(main.app) as c:
+        yield c
+
+
+@pytest.fixture()
+def auth(client: TestClient) -> Dict[str, str]:
+    return _auth_headers(client)
+
+
+def _create(client: TestClient, auth: Dict[str, str], **kw: Any) -> Dict[str, Any]:
+    payload = {"item": "Coding", "hours": 2, "date": "2026-04-19", **kw}
+    r = client.post("/api/time-entries", json=payload, headers=auth)
+    assert r.status_code == 201, r.text
+    return r.json()
+
+
+def test_unauthenticated_returns_401(client: TestClient) -> None:
+    r = client.get("/api/time-entries")
+    assert r.status_code == 401
+
+
+def test_create_and_list(client: TestClient, auth: Dict[str, str]) -> None:
+    _create(client, auth, item="Coding", hours=3.25)
+    _create(client, auth, item="Meeting", hours=1, date="2026-04-18")
+
+    r = client.get("/api/time-entries", headers=auth)
+    assert r.status_code == 200
+    data = r.json()
+    assert len(data) == 2
+    # ordered date desc
+    assert data[0]["date"] >= data[1]["date"]
+
+
+def test_hours_snap_to_quarter(client: TestClient, auth: Dict[str, str]) -> None:
+    e = _create(client, auth, hours=1.13)
+    assert e["hours"] == 1.25  # 1.13 rounds up to 1.25
+    e2 = _create(client, auth, hours=2.7)
+    assert e2["hours"] == 2.75
+
+
+def test_zero_or_negative_hours_rejected(client: TestClient, auth: Dict[str, str]) -> None:
+    r = client.post(
+        "/api/time-entries",
+        json={"item": "x", "hours": 0, "date": "2026-04-19"},
+        headers=auth,
+    )
+    assert r.status_code == 422
+
+    r = client.post(
+        "/api/time-entries",
+        json={"item": "x", "hours": -1, "date": "2026-04-19"},
+        headers=auth,
+    )
+    assert r.status_code == 422
+
+
+def test_bad_date_format_rejected(client: TestClient, auth: Dict[str, str]) -> None:
+    r = client.post(
+        "/api/time-entries",
+        json={"item": "x", "hours": 1, "date": "04/19/2026"},
+        headers=auth,
+    )
+    assert r.status_code == 400
+
+
+def test_empty_item_rejected(client: TestClient, auth: Dict[str, str]) -> None:
+    r = client.post(
+        "/api/time-entries",
+        json={"item": "   ", "hours": 1, "date": "2026-04-19"},
+        headers=auth,
+    )
+    assert r.status_code == 400
+
+
+def test_update_and_delete(client: TestClient, auth: Dict[str, str]) -> None:
+    e = _create(client, auth)
+    r = client.patch(
+        f"/api/time-entries/{e['id']}",
+        json={"hours": 4.5, "item": "Refactor"},
+        headers=auth,
+    )
+    assert r.status_code == 200
+    assert r.json()["hours"] == 4.5
+    assert r.json()["item"] == "Refactor"
+
+    r = client.delete(f"/api/time-entries/{e['id']}", headers=auth)
+    assert r.status_code == 204
+
+    r = client.get("/api/time-entries", headers=auth)
+    assert r.json() == []
+
+
+def test_entries_are_per_user(client: TestClient, auth: Dict[str, str]) -> None:
+    _create(client, auth, item="mine")
+
+    # Create a second user via admin
+    r = client.post(
+        "/api/auth/users",
+        json={"username": "other", "password": "pass12345", "display_name": "Other"},
+        headers=auth,
+    )
+    assert r.status_code == 201, r.text
+
+    r = client.post(
+        "/api/auth/login",
+        json={"username": "other", "password": "pass12345"},
+    )
+    assert r.status_code == 200
+    other_headers = {"Authorization": f"Bearer {r.json()['access_token']}"}
+
+    r = client.get("/api/time-entries", headers=other_headers)
+    assert r.json() == []  # the other user sees none of the admin's entries
+
+    # Other user can't delete admin's entry
+    admin_entries = client.get("/api/time-entries", headers=auth).json()
+    admin_id = admin_entries[0]["id"]
+    r = client.delete(f"/api/time-entries/{admin_id}", headers=other_headers)
+    assert r.status_code == 404
+
+
+def test_date_range_filter(client: TestClient, auth: Dict[str, str]) -> None:
+    _create(client, auth, item="a", date="2026-04-10")
+    _create(client, auth, item="b", date="2026-04-15")
+    _create(client, auth, item="c", date="2026-04-20")
+
+    r = client.get(
+        "/api/time-entries?from=2026-04-12&to=2026-04-18",
+        headers=auth,
+    )
+    assert r.status_code == 200
+    items = [e["item"] for e in r.json()]
+    assert items == ["b"]
+
+
+def test_summary_day(client: TestClient, auth: Dict[str, str]) -> None:
+    _create(client, auth, item="A", hours=2, date="2026-04-19")
+    _create(client, auth, item="A", hours=1, date="2026-04-19")  # same day + item
+    _create(client, auth, item="B", hours=1, date="2026-04-19")
+    _create(client, auth, item="A", hours=4, date="2026-04-18")
+
+    r = client.get("/api/time-entries/summary?period=day", headers=auth)
+    assert r.status_code == 200
+    data = r.json()
+    assert data["period"] == "day"
+    # 2 day buckets, newest first
+    assert [b["key"] for b in data["buckets"]] == ["2026-04-19", "2026-04-18"]
+    today_bucket = data["buckets"][0]
+    assert today_bucket["total"] == 4.0
+    # A should come first (higher hours), percent sums to 100
+    assert today_bucket["items"][0]["item"] == "A"
+    assert today_bucket["items"][0]["hours"] == 3.0
+    assert today_bucket["items"][0]["percent"] == 75.0
+    assert today_bucket["items"][1]["item"] == "B"
+    assert today_bucket["items"][1]["percent"] == 25.0
+    # Overall
+    assert data["overall"]["total"] == 8.0
+
+
+def test_summary_week_buckets_monday(client: TestClient, auth: Dict[str, str]) -> None:
+    # Apr 13 2026 is a Monday. Entries within the same ISO week should bucket.
+    _create(client, auth, item="X", hours=1, date="2026-04-13")  # Mon
+    _create(client, auth, item="X", hours=2, date="2026-04-16")  # Thu
+    _create(client, auth, item="Y", hours=1, date="2026-04-20")  # next Mon
+
+    r = client.get("/api/time-entries/summary?period=week", headers=auth)
+    data = r.json()
+    keys = [b["key"] for b in data["buckets"]]
+    # Newest-first order
+    assert keys == ["2026-04-20", "2026-04-13"]
+    # First week total = 3 (X twice)
+    week1 = [b for b in data["buckets"] if b["key"] == "2026-04-13"][0]
+    assert week1["total"] == 3.0
+
+
+def test_summary_month(client: TestClient, auth: Dict[str, str]) -> None:
+    _create(client, auth, item="A", hours=3, date="2026-04-05")
+    _create(client, auth, item="A", hours=2, date="2026-04-25")
+    _create(client, auth, item="A", hours=1, date="2026-05-02")
+
+    r = client.get("/api/time-entries/summary?period=month", headers=auth)
+    data = r.json()
+    keys = [b["key"] for b in data["buckets"]]
+    assert keys == ["2026-05-01", "2026-04-01"]
+    apr = [b for b in data["buckets"] if b["key"] == "2026-04-01"][0]
+    assert apr["total"] == 5.0
+
+
+def test_summary_period_validation(client: TestClient, auth: Dict[str, str]) -> None:
+    r = client.get("/api/time-entries/summary?period=year", headers=auth)
+    assert r.status_code == 400

--- a/e2e/next-ui.spec.js
+++ b/e2e/next-ui.spec.js
@@ -1,0 +1,59 @@
+import { test, expect } from '@playwright/test';
+import { loginAsAdmin } from './auth-helper.js';
+
+// Smoke tests for the new ("Next") UI toggle and core pages.
+
+async function dismissAnyModals(page) {
+  // In case the first-run Next UI pops the merge picker etc.
+  const close = page.getByRole('button', { name: /Cancel|Close/ });
+  if (await close.count().then(c => c > 0)) {
+    await close.first().click({ trial: true }).catch(() => {});
+  }
+}
+
+test('UI version toggle pill flips between Legacy and Next', async ({ page }) => {
+  await loginAsAdmin(page, expect);
+
+  // Default boot: Legacy UI is visible. Pill says "Legacy".
+  const pill = page.getByRole('button', { name: /UI/ });
+  await expect(pill).toBeVisible();
+  await expect(pill).toContainText('Legacy');
+
+  // Click pill → Next UI shell renders with sidebar items.
+  await pill.click();
+  await expect(pill).toContainText('Next');
+  await expect(page.getByText('Workflow')).toBeVisible();
+  // Sidebar renders the Time log nav link.
+  await expect(page.getByText('Time log').first()).toBeVisible();
+
+  // Click again → back to Legacy.
+  await pill.click();
+  await expect(pill).toContainText('Legacy');
+});
+
+test('?ui=next URL param forces Next UI on load', async ({ page }) => {
+  await loginAsAdmin(page, expect);
+  await page.goto('/?ui=next');
+  const pill = page.getByRole('button', { name: /UI/ });
+  await expect(pill).toContainText('Next');
+  await expect(page.getByText('Workflow')).toBeVisible();
+});
+
+test('Next UI → Time log: can log an entry and see it in the list', async ({ page }) => {
+  await loginAsAdmin(page, expect);
+  await page.goto('/?ui=next#timelog');
+
+  await expect(page.getByRole('heading', { name: 'Time log' })).toBeVisible();
+
+  const itemInput = page.getByPlaceholder(/花時間在什麼上面/);
+  await itemInput.fill('E2E coding');
+  await page.getByRole('button', { name: /Log/ }).click();
+
+  // Entry appears somewhere (list + summary). `.first()` is enough for a smoke test.
+  await expect(page.getByText('E2E coding').first()).toBeVisible();
+  // Hours column shows "1.00h" (default 1)
+  await expect(page.getByText('1.00h').first()).toBeVisible();
+
+  // Summary side panel reflects the entry
+  await expect(page.getByText(/Overall · 1\.00h/)).toBeVisible();
+});

--- a/index.html
+++ b/index.html
@@ -5,6 +5,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" type="image/svg+xml" href="/logo.svg" />
     <title>Burnup Chart</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Geist:wght@300;400;500;600;700&family=Geist+Mono:wght@400;500&display=swap" rel="stylesheet" />
   </head>
   <body class="bg-slate-50">
     <div id="root"></div>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -923,6 +923,12 @@ function BurnupChartInner({ showAdminPanel: _showAdminPanel, setShowAdminPanel }
 
         if (task.actualEnd && task.actualEnd <= date) {
           actualCompleted += points;
+        } else if (task.actualStart && task.actualStart <= date) {
+          const tp = todoProgressByTask[task.id];
+          const progressRatio = tp && tp.total > 0
+            ? tp.done / tp.total
+            : Math.max(0, Math.min(100, task.progress ?? 0)) / 100;
+          actualCompleted += points * progressRatio;
         }
 
         if (task.addedDate === date) dayAdded.push(task.name);
@@ -974,7 +980,7 @@ function BurnupChartInner({ showAdminPanel: _showAdminPanel, setShowAdminPanel }
     });
 
     return { chartData: data, chartAnnotations: annotations };
-  }, [normalizedTasks, dateRangeStats]);
+  }, [normalizedTasks, dateRangeStats, todoProgressByTask]);
 
   // --- Gantt Chart Rendering Logic ---
   const renderGanttChart = () => {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -757,7 +757,13 @@ function BurnupChartInner({ showAdminPanel: _showAdminPanel, setShowAdminPanel }
     if (!showCompleted) {
       filtered = filtered.filter(t => !(t.actualStart && t.actualEnd));
     }
-    return filtered;
+    return [...filtered].sort((a, b) => {
+      const aStart = a.expectedStart || '9999-12-31';
+      const bStart = b.expectedStart || '9999-12-31';
+      if (aStart < bStart) return -1;
+      if (aStart > bStart) return 1;
+      return 0;
+    });
   }, [allTasks, filterPerson, showCompleted]);
 
   // Find active task object for modal

--- a/src/AppRoot.jsx
+++ b/src/AppRoot.jsx
@@ -1,0 +1,77 @@
+// A/B switch wrapper. Renders the legacy <App /> or the new <NewApp />
+// based on a persisted `ui_version` preference. Adds a small floating
+// toggle pill and a Shift+U keyboard shortcut.
+
+import React, { useState, useEffect, useCallback } from 'react';
+import App from './App.jsx';
+import NewApp from './NewApp.jsx';
+
+const STORAGE_KEY = 'ui_version';
+const VERSIONS = ['legacy', 'next'];
+
+function readInitialVersion() {
+  try {
+    const url = new URL(window.location.href);
+    const q = url.searchParams.get('ui');
+    if (VERSIONS.includes(q)) return q;
+  } catch { /* ignore */ }
+  const stored = localStorage.getItem(STORAGE_KEY);
+  return VERSIONS.includes(stored) ? stored : 'legacy';
+}
+
+export default function AppRoot() {
+  const [version, setVersion] = useState(readInitialVersion);
+
+  useEffect(() => {
+    localStorage.setItem(STORAGE_KEY, version);
+  }, [version]);
+
+  const toggle = useCallback(() => {
+    setVersion(v => (v === 'legacy' ? 'next' : 'legacy'));
+  }, []);
+
+  useEffect(() => {
+    const onKey = (e) => {
+      if (!e.shiftKey || e.metaKey || e.ctrlKey || e.altKey) return;
+      if (e.key !== 'U' && e.key !== 'u') return;
+      const tag = document.activeElement?.tagName;
+      if (tag === 'INPUT' || tag === 'TEXTAREA' || document.activeElement?.isContentEditable) return;
+      e.preventDefault();
+      toggle();
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [toggle]);
+
+  return (
+    <>
+      {version === 'next' ? <NewApp /> : <App />}
+      <UiVersionPill version={version} onToggle={toggle} />
+    </>
+  );
+}
+
+function UiVersionPill({ version, onToggle }) {
+  return (
+    <button
+      onClick={onToggle}
+      title="Toggle UI version (Shift+U)"
+      style={{
+        position: 'fixed', left: 12, bottom: 12, zIndex: 2147483000,
+        padding: '5px 10px', fontSize: 11, fontFamily: 'inherit',
+        background: 'rgba(24,24,27,0.78)', color: '#fff',
+        border: '1px solid rgba(255,255,255,0.12)', borderRadius: 999,
+        cursor: 'pointer', backdropFilter: 'blur(6px)',
+        display: 'inline-flex', alignItems: 'center', gap: 6,
+        boxShadow: '0 2px 6px rgba(0,0,0,0.18)',
+        opacity: 0.65, transition: 'opacity 120ms ease',
+      }}
+      onMouseEnter={(e) => (e.currentTarget.style.opacity = '1')}
+      onMouseLeave={(e) => (e.currentTarget.style.opacity = '0.65')}
+    >
+      <span style={{ opacity: 0.7, fontSize: 10, letterSpacing: 0.4, textTransform: 'uppercase' }}>UI</span>
+      <span style={{ fontWeight: 600 }}>{version === 'next' ? 'Next' : 'Legacy'}</span>
+      <span style={{ opacity: 0.55, fontSize: 10 }}>⇧U</span>
+    </button>
+  );
+}

--- a/src/NewApp.jsx
+++ b/src/NewApp.jsx
@@ -1,0 +1,172 @@
+// "Next" UI — shell + all redesigned pages. Data + modal orchestration live here.
+
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { T, FONT } from './design/tokens.js';
+import { Shell } from './design/layout/Shell.jsx';
+import { useAppData } from './hooks/useAppData.js';
+import { BurnupPage } from './pages/BurnupPage.jsx';
+import { GanttPage } from './pages/GanttPage.jsx';
+import { TodosPage } from './pages/TodosPage.jsx';
+import { SubProjectsPage } from './pages/SubProjectsPage.jsx';
+import { MergedPage } from './pages/MergedPage.jsx';
+import { TimeLogPage } from './pages/TimeLogPage.jsx';
+import { LoginPage } from './pages/LoginPage.jsx';
+import { EmptyProject } from './components/EmptyProject.jsx';
+import { SearchModal } from './components/modals/SearchModal.jsx';
+import { TaskDetailModal } from './components/modals/TaskDetailModal.jsx';
+import { useAuth } from './auth/AuthContext.jsx';
+
+const PAGE_KEYS = ['burnup', 'gantt', 'todos', 'subs', 'merged', 'timelog'];
+
+function readHashPage() {
+  const h = window.location.hash.slice(1);
+  return PAGE_KEYS.includes(h) ? h : 'burnup';
+}
+
+export default function NewApp() {
+  const { user, isLoading: authLoading } = useAuth();
+
+  // If not authenticated, show the new login screen.
+  if (authLoading) return <BootingScreen />;
+  if (!user) return <LoginPage />;
+
+  return <AuthenticatedApp />;
+}
+
+function AuthenticatedApp() {
+  const [page, setPage] = useState(readHashPage);
+  const data = useAppData();
+
+  // Global modal state
+  const [searchOpen, setSearchOpen] = useState(false);
+  const [detailTask, setDetailTask] = useState(null);
+  const [pendingEditTodoId, setPendingEditTodoId] = useState(null);
+
+  // Cmd+K / Ctrl+K opens search
+  useEffect(() => {
+    const onKey = (e) => {
+      if ((e.metaKey || e.ctrlKey) && (e.key === 'k' || e.key === 'K')) {
+        e.preventDefault();
+        setSearchOpen(true);
+      }
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, []);
+
+  // Hash routing
+  useEffect(() => {
+    window.history.replaceState(null, '', `#${page}`);
+  }, [page]);
+  useEffect(() => {
+    const onHash = () => setPage(readHashPage());
+    window.addEventListener('hashchange', onHash);
+    return () => window.removeEventListener('hashchange', onHash);
+  }, []);
+
+  const sidebarProjects = useMemo(() => data.projects.map(p => ({
+    id: p.id,
+    name: p.name,
+    count: (p.tasks || []).length,
+  })), [data.projects]);
+
+  const handlePickTask = useCallback((t) => {
+    setDetailTask(t);
+  }, []);
+
+  const handlePickTodo = useCallback((todo) => {
+    setPage('todos');
+    setPendingEditTodoId(todo.id);
+  }, []);
+
+  const needsEmptyState = !data.loading && page === 'burnup' && data.activeProject && data.allTasks.length === 0;
+
+  return (
+    <Shell
+      active={page}
+      project={data.activeProject?.name || 'Untitled'}
+      user={data.user}
+      projects={sidebarProjects}
+      activeProjectId={data.activeProjectId}
+      onSelectProject={data.setActiveProjectId}
+      onNavigate={setPage}
+      onOpenSearch={() => setSearchOpen(true)}
+    >
+      {data.loading ? (
+        <LoadingState />
+      ) : data.error ? (
+        <ErrorState error={data.error} />
+      ) : needsEmptyState ? (
+        <EmptyProject projectName={data.activeProject?.name} />
+      ) : page === 'burnup' ? (
+        <BurnupPage data={{ ...data, onSelectTask: handlePickTask }} />
+      ) : page === 'gantt' ? (
+        <GanttPage data={{ ...data, onSelectTask: handlePickTask }} />
+      ) : page === 'todos' ? (
+        <TodosPage
+          data={data}
+          initialEditTodoId={pendingEditTodoId}
+          onClearInitialEditTodoId={() => setPendingEditTodoId(null)}
+        />
+      ) : page === 'subs' ? (
+        <SubProjectsPage data={data} />
+      ) : page === 'merged' ? (
+        <MergedPage data={data} />
+      ) : page === 'timelog' ? (
+        <TimeLogPage data={data} />
+      ) : null}
+
+      {searchOpen && (
+        <SearchModal
+          tasks={data.allTasks}
+          todos={data.todos}
+          endStatusId={data.statuses.find(s => s.isDefaultEnd)?.id}
+          today={data.today}
+          onPickTask={handlePickTask}
+          onPickTodo={handlePickTodo}
+          onClose={() => setSearchOpen(false)}
+        />
+      )}
+
+      {detailTask && (
+        <TaskDetailModal
+          task={detailTask}
+          todos={data.todos}
+          statuses={data.statuses}
+          onClose={() => setDetailTask(null)}
+        />
+      )}
+    </Shell>
+  );
+}
+
+function BootingScreen() {
+  return (
+    <div style={{
+      height: '100vh', background: T.bg, display: 'flex',
+      alignItems: 'center', justifyContent: 'center',
+      fontFamily: FONT, fontSize: 12, color: T.textDim,
+    }}>
+      Booting…
+    </div>
+  );
+}
+
+function LoadingState() {
+  return (
+    <div style={{
+      height: '100%', display: 'flex', alignItems: 'center', justifyContent: 'center',
+      color: T.textDim, fontSize: 12, fontFamily: FONT,
+    }}>
+      Loading…
+    </div>
+  );
+}
+
+function ErrorState({ error }) {
+  return (
+    <div style={{ padding: 24, fontFamily: FONT, color: T.danger, fontSize: 13 }}>
+      Failed to load data: {String(error?.message || error)}
+    </div>
+  );
+}

--- a/src/api.js
+++ b/src/api.js
@@ -35,6 +35,12 @@ export async function requestJson(path, options = {}) {
   return response.json();
 }
 
+export async function fetchActivity(projectId, limit = 50) {
+  if (!projectId) return [];
+  const params = new URLSearchParams({ project_id: projectId, limit: String(limit) });
+  return requestJson(`/api/activity?${params.toString()}`);
+}
+
 export async function requestJsonNoAuth(path, options = {}) {
   const response = await fetch(`${API_BASE}${path}`, {
     ...options,

--- a/src/components/EmptyProject.jsx
+++ b/src/components/EmptyProject.jsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { T } from '../design/tokens.js';
+import { I, ICON, Btn } from '../design/primitives.jsx';
+
+// Empty-state card shown when a project has no tasks.
+
+export function EmptyProject({ projectName, onCreateTask, onImportCsv }) {
+  return (
+    <div style={{
+      padding: 40, height: '100%', background: T.bg,
+      display: 'flex', alignItems: 'center', justifyContent: 'center',
+    }}>
+      <div style={{ textAlign: 'center', maxWidth: 380 }}>
+        <div style={{
+          width: 56, height: 56, borderRadius: 10, background: T.surface2,
+          border: `1px solid ${T.border}`, margin: '0 auto 14px',
+          display: 'flex', alignItems: 'center', justifyContent: 'center',
+          color: T.textDim,
+        }}>
+          <I d={ICON.folder} size={24} />
+        </div>
+        <div style={{ fontSize: 16, fontWeight: 600, marginBottom: 4 }}>
+          {projectName ? `${projectName} is empty` : 'Start a new project'}
+        </div>
+        <div style={{ fontSize: 12, color: T.textMute, marginBottom: 18, lineHeight: 1.5 }}>
+          Projects group tasks into a burnup. Create tasks one by one and let the system auto-plan end dates around Taiwan holidays, or import a CSV.
+        </div>
+        <div style={{ display: 'flex', gap: 6, justifyContent: 'center', flexWrap: 'wrap' }}>
+          {onCreateTask && (
+            <Btn variant="primary" icon="plus" onClick={onCreateTask}>Add first task</Btn>
+          )}
+          {onImportCsv && (
+            <Btn variant="subtle" icon="upload" onClick={onImportCsv}>Import CSV</Btn>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/burnup/ActivityRail.jsx
+++ b/src/components/burnup/ActivityRail.jsx
@@ -1,0 +1,85 @@
+import React from 'react';
+import { T } from '../../design/tokens.js';
+import { ActivityGlyph, Badge } from '../../design/primitives.jsx';
+import { formatRelative } from '../../design/formatTime.js';
+
+// Phase 3: consumes the unified /api/activity feed (logs + todo comments +
+// sub-project events) via useAppData's `activity` array.
+
+function toneFor(kind) {
+  switch (kind) {
+    case 'waiting':  return 'warn';
+    case 'decision': return 'violet';
+    case 'comment':  return 'iris';
+    case 'note':     return 'neutral';
+    case 'log':
+    default:         return 'neutral';
+  }
+}
+
+function ActivityItem({ a }) {
+  return (
+    <div style={{ display: 'flex', gap: 8, padding: '8px 0', borderBottom: `1px solid ${T.divider}` }}>
+      <ActivityGlyph kind={a.kind} />
+      <div style={{ flex: 1, minWidth: 0, fontSize: 12 }}>
+        <div style={{ display: 'flex', alignItems: 'baseline', gap: 6, marginBottom: 2, flexWrap: 'wrap' }}>
+          <span style={{ fontWeight: 500 }}>{a.who || '—'}</span>
+          <Badge tone={toneFor(a.kind)} size="sm">{a.kind}</Badge>
+          <span style={{ fontSize: 10, color: T.textDim, marginLeft: 'auto' }}>{formatRelative(a.when)}</span>
+        </div>
+        {a.text && (
+          <div style={{ color: T.textMute, lineHeight: 1.5, wordBreak: 'break-word' }}>
+            {a.text}
+          </div>
+        )}
+        {a.context && (
+          <div style={{ fontSize: 10, color: T.textDim, marginTop: 3 }}>↳ {a.context}</div>
+        )}
+        {a.waitingOn && (
+          <div style={{ fontSize: 11, color: T.warn, marginTop: 3 }}>↪ {a.waitingOn}</div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export function ActivityRail({ items = [], loading = false }) {
+  return (
+    <div style={{
+      background: T.surface, border: `1px solid ${T.border}`, borderRadius: 6,
+      padding: '10px 12px', display: 'flex', flexDirection: 'column', minHeight: 0,
+    }}>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 4 }}>
+        <div style={{ fontSize: 12, fontWeight: 600 }}>Activity</div>
+        <span style={{
+          display: 'inline-flex', alignItems: 'center', gap: 5,
+          fontSize: 10, color: T.textDim,
+        }}>
+          <span style={{
+            width: 6, height: 6, borderRadius: 6,
+            background: loading ? T.today : T.green,
+            boxShadow: loading ? 'none' : `0 0 0 2px ${T.greenSoft}`,
+            transition: 'background 160ms ease',
+          }} />
+          {loading ? 'syncing' : 'live'}
+        </span>
+      </div>
+      <div style={{ fontSize: 10, color: T.textDim, marginBottom: 4 }}>
+        Unified log · comment · event
+      </div>
+      <div style={{ flex: 1, overflow: 'auto', minHeight: 0 }}>
+        {loading && items.length === 0 ? (
+          <div style={{ fontSize: 11, color: T.textDim, padding: '12px 0', textAlign: 'center' }}>
+            Loading…
+          </div>
+        ) : items.length === 0 ? (
+          <div style={{ fontSize: 11, color: T.textDim, padding: '12px 0', textAlign: 'center' }}>
+            尚無活動紀錄
+          </div>
+        ) : (
+          items.map((a) => <ActivityItem key={a.id} a={a} />)
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/burnup/BurnupChart.jsx
+++ b/src/components/burnup/BurnupChart.jsx
@@ -1,0 +1,280 @@
+import React, { useRef, useState, useCallback } from 'react';
+import { T, MONO, FONT, weekCode } from '../../design/tokens.js';
+
+// SVG burnup chart — curve | step | area styles.
+// Adapts the design bundle's BurnupChart to real data shape.
+
+export function BurnupChart({ data, annotations = [], style = 'curve', height = 260, today }) {
+  const h = height;
+  const w = 640;
+  const padL = 32, padR = 12, padT = 10, padB = 22;
+  const innerW = w - padL - padR;
+  const innerH = h - padT - padB;
+
+  const wrapRef = useRef(null);
+  const [hoverIdx, setHoverIdx] = useState(-1);
+
+  const xs = data && data.length > 0
+    ? data.map((_, i) => padL + (i / Math.max(1, data.length - 1)) * innerW)
+    : [];
+
+  const onMouseMove = useCallback((e) => {
+    const el = wrapRef.current;
+    if (!el || xs.length === 0) return;
+    const rect = el.getBoundingClientRect();
+    // Map mouse X (pixels) back to viewBox coords.
+    const vx = ((e.clientX - rect.left) / rect.width) * w;
+    // Find nearest data index.
+    let best = 0, bestDist = Infinity;
+    for (let i = 0; i < xs.length; i++) {
+      const d = Math.abs(xs[i] - vx);
+      if (d < bestDist) { best = i; bestDist = d; }
+    }
+    setHoverIdx(best);
+  }, [xs]);
+
+  const onMouseLeave = useCallback(() => setHoverIdx(-1), []);
+
+  if (!data || data.length === 0) {
+    return (
+      <div style={{ height: h, display: 'flex', alignItems: 'center', justifyContent: 'center', color: T.textDim, fontSize: 12 }}>
+        No data yet — add a task with dates to see the chart.
+      </div>
+    );
+  }
+
+  const y = v => padT + innerH - (v / 100) * innerH;
+
+  const build = (key, stepped) => {
+    const pts = data.map((d, i) => d[key] != null ? [xs[i], y(d[key])] : null).filter(Boolean);
+    if (!pts.length) return '';
+    if (stepped) {
+      let p = `M${pts[0][0]},${pts[0][1]}`;
+      for (let i = 1; i < pts.length; i++) {
+        p += ` L${pts[i][0]},${pts[i - 1][1]} L${pts[i][0]},${pts[i][1]}`;
+      }
+      return p;
+    }
+    let p = `M${pts[0][0]},${pts[0][1]}`;
+    for (let i = 1; i < pts.length; i++) {
+      const [x0, y0] = pts[i - 1];
+      const [x1, y1] = pts[i];
+      const cx = (x0 + x1) / 2;
+      p += ` C${cx},${y0} ${cx},${y1} ${x1},${y1}`;
+    }
+    return p;
+  };
+
+  const stepped = style === 'step';
+  const area = style === 'area';
+  const expPath = build('exp', stepped);
+  const actPath = build('act', stepped);
+
+  let actAreaPath = '';
+  if (area && actPath) {
+    const lastIdx = (() => {
+      for (let i = data.length - 1; i >= 0; i--) if (data[i].act != null) return i;
+      return -1;
+    })();
+    if (lastIdx >= 0) {
+      actAreaPath = actPath + ` L${xs[lastIdx]},${y(0)} L${xs[0]},${y(0)} Z`;
+    }
+  }
+
+  const todayIdx = today ? data.findIndex(d => d.d === today) : -1;
+  const todayX = todayIdx >= 0 ? xs[todayIdx] : null;
+
+  const labelEvery = Math.max(1, Math.floor(data.length / 8));
+  const hoverX = hoverIdx >= 0 ? xs[hoverIdx] : null;
+  const hoverPoint = hoverIdx >= 0 ? data[hoverIdx] : null;
+
+  // Tooltip positioning: in container % (clamped so it doesn't escape right edge).
+  const tooltipLeftPct = hoverX != null ? Math.max(2, Math.min(100, (hoverX / w) * 100)) : 0;
+  const flipRight = tooltipLeftPct > 65;
+
+  return (
+    <div
+      ref={wrapRef}
+      onMouseMove={onMouseMove}
+      onMouseLeave={onMouseLeave}
+      style={{ position: 'relative', width: '100%', height: h, cursor: 'crosshair' }}
+    >
+      <svg viewBox={`0 0 ${w} ${h}`} width="100%" height={h} style={{ display: 'block' }}>
+        {/* gridlines */}
+        {[0, 25, 50, 75, 100].map(v => (
+          <g key={v}>
+            <line x1={padL} x2={w - padR} y1={y(v)} y2={y(v)} stroke={T.divider} strokeWidth="1" />
+            <text x={padL - 6} y={y(v) + 3} fontSize="9" fill={T.textDim} fontFamily={MONO} textAnchor="end">{v}</text>
+          </g>
+        ))}
+        {/* x labels */}
+        {data.map((d, i) => (i % labelEvery === 0 || i === data.length - 1) && (
+          <text key={i} x={xs[i]} y={h - 6} fontSize="9" fill={T.textDim} fontFamily={MONO} textAnchor="middle">
+            {d.d.slice(5)}
+          </text>
+        ))}
+
+        {/* today line */}
+        {todayX != null && (
+          <g>
+            <line x1={todayX} x2={todayX} y1={padT} y2={h - padB} stroke={T.today} strokeWidth="1" strokeDasharray="3 3" />
+            <rect x={todayX - 16} y={padT - 2} width="32" height="12" rx="2" fill={T.today} />
+            <text x={todayX} y={padT + 7} fontSize="9" fontWeight="600" fill="#fff" textAnchor="middle">TODAY</text>
+          </g>
+        )}
+
+        {/* hover indicator */}
+        {hoverX != null && (
+          <line
+            x1={hoverX} x2={hoverX} y1={padT} y2={h - padB}
+            stroke={T.textDim} strokeWidth="1" strokeDasharray="2 2"
+          />
+        )}
+
+        {/* expected (dashed iris) */}
+        <path d={expPath} fill="none" stroke={T.iris} strokeWidth="1.5" strokeDasharray="4 3" />
+
+        {/* actual */}
+        {area && actAreaPath && <path d={actAreaPath} fill={T.green} fillOpacity="0.08" />}
+        <path d={actPath} fill="none" stroke={T.green} strokeWidth="2" />
+
+        {/* actual dots */}
+        {data.map((d, i) => d.act != null && (
+          <circle
+            key={i}
+            cx={xs[i]}
+            cy={y(d.act)}
+            r={i === hoverIdx ? 4 : i === todayIdx ? 3.5 : 2.5}
+            fill={T.surface}
+            stroke={T.green}
+            strokeWidth={i === hoverIdx ? 2 : 1.5}
+          />
+        ))}
+
+        {/* hovered expected point (highlight) */}
+        {hoverIdx >= 0 && hoverPoint?.exp != null && (
+          <circle
+            cx={xs[hoverIdx]}
+            cy={y(hoverPoint.exp)}
+            r={3}
+            fill={T.surface}
+            stroke={T.iris}
+            strokeWidth="1.5"
+          />
+        )}
+
+        {/* task labels (annotations) */}
+        {annotations.map((a, i) => {
+          const ax = xs[data.findIndex(d => d.d === a.date)];
+          if (ax == null) return null;
+          const ay = y(a.value);
+          const stroke = a.isActual ? T.green : T.iris;
+          const label = `${a.name} · ${a.points}pt`;
+          // Approximate character width for placement (mono 9px ~ 5px per char).
+          const textLen = Math.min(180, Math.max(60, label.length * 5.4));
+          // Alternate above/below by index to reduce overlap on dense dates.
+          const above = i % 2 === 0;
+          const boxH = 14;
+          const gap = 12;
+          const boxY = above ? Math.max(padT, ay - gap - boxH) : Math.min(h - padB - boxH, ay + gap);
+          // Keep box within horizontal chart bounds.
+          const boxX = Math.max(padL, Math.min(w - padR - textLen, ax - textLen / 2));
+          const stickY1 = above ? ay - 1 : ay + 1;
+          const stickY2 = above ? boxY + boxH : boxY;
+          return (
+            <g key={a.id} style={{ pointerEvents: 'none' }}>
+              <line x1={ax} y1={stickY1} x2={ax} y2={stickY2} stroke={T.textDim} strokeWidth="0.5" />
+              <rect
+                x={boxX} y={boxY} width={textLen} height={boxH} rx="2"
+                fill={T.surface} stroke={stroke} strokeWidth="0.8" strokeOpacity="0.6"
+              />
+              <text
+                x={boxX + 4} y={boxY + 10}
+                fontSize="9" fontFamily={FONT} fill={T.textMute}
+              >
+                {label}
+              </text>
+            </g>
+          );
+        })}
+      </svg>
+
+      {/* HTML tooltip floating above SVG */}
+      {hoverPoint && (
+        <div
+          style={{
+            position: 'absolute',
+            left: `${tooltipLeftPct}%`,
+            top: 8,
+            transform: flipRight ? 'translateX(calc(-100% - 10px))' : 'translateX(10px)',
+            pointerEvents: 'none',
+            background: T.surface,
+            border: `1px solid ${T.border}`,
+            borderRadius: 6,
+            padding: '8px 10px',
+            fontFamily: FONT,
+            fontSize: 11,
+            minWidth: 148,
+            boxShadow: '0 4px 12px rgba(0,0,0,0.08)',
+            zIndex: 2,
+          }}
+        >
+          <div style={{ display: 'flex', alignItems: 'baseline', justifyContent: 'space-between', marginBottom: 6, gap: 6 }}>
+            <span style={{ fontFamily: MONO, fontSize: 11, color: T.text, fontWeight: 600 }}>
+              {hoverPoint.d}
+            </span>
+            <span style={{ fontSize: 9.5, color: T.textDim, fontFamily: MONO, letterSpacing: 0.3 }}>
+              {weekCode(hoverPoint.d)}
+            </span>
+          </div>
+          <Row color={T.iris} label="Planned" value={hoverPoint.exp} dashed />
+          <Row color={T.green} label="Actual" value={hoverPoint.act} />
+          {hoverPoint.exp != null && hoverPoint.act != null && (
+            <div style={{
+              marginTop: 5, paddingTop: 5, borderTop: `1px solid ${T.divider}`,
+              fontSize: 10, color: T.textDim, display: 'flex', justifyContent: 'space-between',
+            }}>
+              <span>Δ</span>
+              <DeltaValue delta={hoverPoint.act - hoverPoint.exp} />
+            </div>
+          )}
+          {hoverPoint.d === today && (
+            <div style={{
+              marginTop: 4, fontSize: 10, color: T.today, fontWeight: 600,
+              letterSpacing: 0.4, textTransform: 'uppercase',
+            }}>· Today</div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function Row({ color, label, value, dashed }) {
+  const display = value == null ? '—' : `${value.toFixed(1)}%`;
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 8, marginTop: 2 }}>
+      <span style={{ display: 'inline-flex', alignItems: 'center', gap: 6, color: T.textMute }}>
+        <span style={{
+          width: 10, height: 2, background: color, borderRadius: 1,
+          backgroundImage: dashed ? `repeating-linear-gradient(90deg, ${color} 0 3px, transparent 3px 6px)` : undefined,
+        }} />
+        {label}
+      </span>
+      <span style={{ fontFamily: MONO, fontSize: 11, color: value == null ? T.textDim : T.text, fontWeight: 500 }}>
+        {display}
+      </span>
+    </div>
+  );
+}
+
+function DeltaValue({ delta }) {
+  const rounded = +delta.toFixed(1);
+  const color = Math.abs(rounded) < 0.5 ? T.textMute : rounded > 0 ? T.green : T.warn;
+  const sign = rounded > 0 ? '+' : '';
+  return (
+    <span style={{ fontFamily: MONO, color, fontWeight: 500 }}>
+      {sign}{rounded}%
+    </span>
+  );
+}

--- a/src/components/burnup/BurnupChart.jsx
+++ b/src/components/burnup/BurnupChart.jsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState, useCallback } from 'react';
+import React, { useRef, useState, useCallback, useMemo } from 'react';
 import { T, MONO, FONT, weekCode } from '../../design/tokens.js';
 
 // SVG burnup chart — curve | step | area styles.
@@ -14,9 +14,12 @@ export function BurnupChart({ data, annotations = [], style = 'curve', height = 
   const wrapRef = useRef(null);
   const [hoverIdx, setHoverIdx] = useState(-1);
 
-  const xs = data && data.length > 0
-    ? data.map((_, i) => padL + (i / Math.max(1, data.length - 1)) * innerW)
-    : [];
+  const xs = useMemo(
+    () => data && data.length > 0
+      ? data.map((_, i) => padL + (i / Math.max(1, data.length - 1)) * innerW)
+      : [],
+    [data, padL, innerW],
+  );
 
   const onMouseMove = useCallback((e) => {
     const el = wrapRef.current;

--- a/src/components/burnup/KpiStrip.jsx
+++ b/src/components/burnup/KpiStrip.jsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import { T, FONT } from '../../design/tokens.js';
+
+function KPI({ label, value, hint, tone = 'neutral' }) {
+  const toneColor = {
+    iris: T.iris, green: T.green, warn: T.warn, danger: T.danger, neutral: T.textMute,
+  }[tone] || T.textMute;
+  return (
+    <div style={{
+      flex: 1, padding: '10px 14px', background: T.surface,
+      border: `1px solid ${T.border}`, borderRadius: 6,
+      display: 'flex', flexDirection: 'column', gap: 2, minWidth: 0,
+    }}>
+      <div style={{ fontSize: 11, color: T.textMute, display: 'flex', alignItems: 'center', gap: 6 }}>
+        <span style={{ width: 6, height: 6, borderRadius: 6, background: toneColor, display: 'inline-block' }} />
+        {label}
+      </div>
+      <div style={{ fontSize: 22, fontWeight: 600, fontFamily: FONT, letterSpacing: -0.5, lineHeight: 1.1 }}>
+        {value}
+      </div>
+      <div style={{ fontSize: 10, color: T.textDim }}>{hint}</div>
+    </div>
+  );
+}
+
+export function KpiStrip({ scope, completed, planned, velocity, atRisk, scopeDelta = 0 }) {
+  const pctCompleted = scope > 0 ? Math.round((completed / scope) * 100) : 0;
+  return (
+    <div style={{ display: 'flex', gap: 8, marginBottom: 12 }}>
+      <KPI
+        label="Scope"
+        value={`${scope} pts`}
+        hint={scopeDelta ? `${scopeDelta > 0 ? '+' : ''}${scopeDelta} this week` : 'total points'}
+      />
+      <KPI
+        label="Completed"
+        value={`${Math.round(completed)} pts`}
+        hint={`${pctCompleted}% of scope`}
+        tone="green"
+      />
+      <KPI
+        label="Planned"
+        value={`${Math.round(planned)} pts`}
+        hint="expected today"
+        tone="iris"
+      />
+      <KPI
+        label="Velocity"
+        value={`${velocity.toFixed(1)} pt/d`}
+        hint="last 7 days"
+      />
+      <KPI
+        label="At risk"
+        value={String(atRisk)}
+        hint="same-assignee overlap"
+        tone={atRisk > 0 ? 'warn' : 'neutral'}
+      />
+    </div>
+  );
+}

--- a/src/components/burnup/ProgressCell.jsx
+++ b/src/components/burnup/ProgressCell.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useRef, useState } from 'react';
 import { T, MONO } from '../../design/tokens.js';
 
 // Drag to set + click-to-type percentage cell.
@@ -13,7 +13,13 @@ export function ProgressCell({ value, onCommit, done, disabled }) {
   const [dragValue, setDragValue] = useState(value ?? 0);
   const barRef = useRef(null);
 
-  useEffect(() => { setTyped(String(value ?? 0)); }, [value]);
+  // Sync the local typed draft when the committed value changes via
+  // render-time state update (instead of useEffect+setState).
+  const [lastValue, setLastValue] = useState(value);
+  if (value !== lastValue) {
+    setLastValue(value);
+    setTyped(String(value ?? 0));
+  }
 
   const commitFromMouse = (e) => {
     const el = barRef.current;

--- a/src/components/burnup/ProgressCell.jsx
+++ b/src/components/burnup/ProgressCell.jsx
@@ -1,0 +1,127 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { T, MONO } from '../../design/tokens.js';
+
+// Drag to set + click-to-type percentage cell.
+// Ports design bundle's ProgressCell verbatim behaviour, with an onCommit
+// callback that persists the value to the backend.
+
+export function ProgressCell({ value, onCommit, done, disabled }) {
+  const [hover, setHover] = useState(false);
+  const [editing, setEditing] = useState(false);
+  const [typed, setTyped] = useState(String(value ?? 0));
+  const [drafting, setDrafting] = useState(false);
+  const [dragValue, setDragValue] = useState(value ?? 0);
+  const barRef = useRef(null);
+
+  useEffect(() => { setTyped(String(value ?? 0)); }, [value]);
+
+  const commitFromMouse = (e) => {
+    const el = barRef.current;
+    if (!el) return;
+    const r = el.getBoundingClientRect();
+    const pct = Math.round(Math.max(0, Math.min(100, ((e.clientX - r.left) / r.width) * 100)) / 5) * 5;
+    setDragValue(pct);
+  };
+
+  const onDown = (e) => {
+    if (done || disabled) return;
+    setDrafting(true);
+    commitFromMouse(e);
+    const move = (ev) => commitFromMouse(ev);
+    const up = (ev) => {
+      commitFromMouse(ev);
+      setDrafting(false);
+      window.removeEventListener('mousemove', move);
+      window.removeEventListener('mouseup', up);
+      // Commit on release using the latest drag value.
+      const el = barRef.current;
+      if (el) {
+        const r = el.getBoundingClientRect();
+        const pct = Math.round(Math.max(0, Math.min(100, ((ev.clientX - r.left) / r.width) * 100)) / 5) * 5;
+        if (pct !== value) onCommit?.(pct);
+      }
+    };
+    window.addEventListener('mousemove', move);
+    window.addEventListener('mouseup', up);
+  };
+
+  const displayValue = drafting ? dragValue : (value ?? 0);
+
+  if (editing) {
+    return (
+      <div style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
+        <input
+          autoFocus
+          type="number"
+          min={0}
+          max={100}
+          value={typed}
+          onChange={e => setTyped(e.target.value)}
+          onBlur={() => {
+            const n = Math.max(0, Math.min(100, parseInt(typed || '0', 10) || 0));
+            if (n !== value) onCommit?.(n);
+            setEditing(false);
+          }}
+          onKeyDown={e => {
+            if (e.key === 'Enter') e.currentTarget.blur();
+            if (e.key === 'Escape') { setTyped(String(value ?? 0)); setEditing(false); }
+          }}
+          style={{
+            width: 50, padding: '2px 5px', fontFamily: MONO, fontSize: 11,
+            border: `1px solid ${T.iris}`, borderRadius: 4, outline: 'none',
+            boxShadow: `0 0 0 2px ${T.irisSoft}`,
+          }}
+        />
+        <span style={{ fontFamily: MONO, fontSize: 10, color: T.textMute }}>%</span>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      onMouseEnter={() => setHover(true)}
+      onMouseLeave={() => !drafting && setHover(false)}
+      style={{
+        display: 'flex', alignItems: 'center', gap: 6,
+        cursor: (done || disabled) ? 'not-allowed' : 'pointer',
+      }}
+      title={done ? 'Task completed — locked at 100%' : 'Drag to set · click number to type'}
+    >
+      <div
+        ref={barRef}
+        onMouseDown={onDown}
+        style={{
+          position: 'relative', flex: 1,
+          height: hover && !done && !disabled ? 8 : 4,
+          background: T.surface2, borderRadius: 4, overflow: 'hidden',
+          transition: 'height 100ms ease',
+          border: hover && !done && !disabled ? `1px solid ${T.borderStrong}` : '1px solid transparent',
+        }}
+      >
+        <div style={{
+          width: `${displayValue}%`, height: '100%',
+          background: done ? T.green : displayValue > 0 ? T.iris : 'transparent',
+          transition: drafting ? 'none' : 'width 120ms ease',
+        }} />
+        {hover && !done && !disabled && (
+          <div style={{
+            position: 'absolute', top: '50%', left: `${displayValue}%`,
+            transform: 'translate(-50%, -50%)', width: 10, height: 10,
+            borderRadius: 10, background: '#fff', border: `2px solid ${T.iris}`,
+            pointerEvents: 'none',
+          }} />
+        )}
+      </div>
+      <span
+        onClick={(e) => { if (!done && !disabled) { e.stopPropagation(); setEditing(true); } }}
+        style={{
+          fontFamily: MONO, fontSize: 10,
+          color: hover && !done && !disabled ? T.iris : T.textMute,
+          minWidth: 28, textAlign: 'right',
+          textDecoration: hover && !done && !disabled ? 'underline dotted' : 'none',
+          textUnderlineOffset: 2,
+        }}
+      >{displayValue}%</span>
+    </div>
+  );
+}

--- a/src/components/burnup/ProgressCell.test.jsx
+++ b/src/components/burnup/ProgressCell.test.jsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import { describe, test, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ProgressCell } from './ProgressCell.jsx';
+
+describe('ProgressCell', () => {
+  test('renders the current value as percent', () => {
+    render(<ProgressCell value={42} onCommit={() => {}} />);
+    expect(screen.getByText('42%')).toBeInTheDocument();
+  });
+
+  test('clicking the percent number switches to input mode', () => {
+    render(<ProgressCell value={30} onCommit={() => {}} />);
+    fireEvent.click(screen.getByText('30%'));
+    // In edit mode we see a number input prefilled with the value
+    expect(screen.getByRole('spinbutton')).toHaveValue(30);
+  });
+
+  test('Enter commits the typed value through onCommit', () => {
+    const onCommit = vi.fn();
+    render(<ProgressCell value={30} onCommit={onCommit} />);
+    fireEvent.click(screen.getByText('30%'));
+    const input = screen.getByRole('spinbutton');
+    fireEvent.change(input, { target: { value: '65' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+    expect(onCommit).toHaveBeenCalledWith(65);
+  });
+
+  test('Escape cancels and does not commit', () => {
+    const onCommit = vi.fn();
+    render(<ProgressCell value={30} onCommit={onCommit} />);
+    fireEvent.click(screen.getByText('30%'));
+    const input = screen.getByRole('spinbutton');
+    fireEvent.change(input, { target: { value: '99' } });
+    fireEvent.keyDown(input, { key: 'Escape' });
+    expect(onCommit).not.toHaveBeenCalled();
+    // Back to display mode with original value
+    expect(screen.getByText('30%')).toBeInTheDocument();
+  });
+
+  test('clamps typed values outside 0..100', () => {
+    const onCommit = vi.fn();
+    render(<ProgressCell value={20} onCommit={onCommit} />);
+    fireEvent.click(screen.getByText('20%'));
+    const input = screen.getByRole('spinbutton');
+    fireEvent.change(input, { target: { value: '150' } });
+    fireEvent.blur(input);
+    expect(onCommit).toHaveBeenCalledWith(100);
+  });
+
+  test('done=true locks the display — click does not enter edit mode', () => {
+    const onCommit = vi.fn();
+    render(<ProgressCell value={100} done onCommit={onCommit} />);
+    fireEvent.click(screen.getByText('100%'));
+    expect(screen.queryByRole('spinbutton')).not.toBeInTheDocument();
+    expect(onCommit).not.toHaveBeenCalled();
+  });
+
+  test('disabled prevents entering edit mode', () => {
+    const onCommit = vi.fn();
+    render(<ProgressCell value={50} disabled onCommit={onCommit} />);
+    fireEvent.click(screen.getByText('50%'));
+    expect(screen.queryByRole('spinbutton')).not.toBeInTheDocument();
+  });
+
+  test('prop updates reflect immediately in display', () => {
+    const { rerender } = render(<ProgressCell value={10} onCommit={() => {}} />);
+    expect(screen.getByText('10%')).toBeInTheDocument();
+    rerender(<ProgressCell value={75} onCommit={() => {}} />);
+    expect(screen.getByText('75%')).toBeInTheDocument();
+  });
+});

--- a/src/components/burnup/TaskTable.jsx
+++ b/src/components/burnup/TaskTable.jsx
@@ -1,0 +1,188 @@
+import React from 'react';
+import { T, MONO, weekCodeRange } from '../../design/tokens.js';
+import { I, ICON, Avatar, Btn } from '../../design/primitives.jsx';
+import { ProgressCell } from './ProgressCell.jsx';
+
+function TaskRow({ t, onUpdateProgress, onToggleShowLabel, onSelectTask }) {
+  const done = (t.progress ?? 0) === 100 || !!t.actualEnd;
+  const overlap = t._overlap || 1;
+  const overlapBg = overlap === 2
+    ? 'rgba(217,119,6,0.05)'
+    : overlap >= 3 ? 'rgba(220,38,38,0.05)' : 'transparent';
+  const short = (d) => d ? d.slice(5) : '';
+  const rowOpacity = done ? 0.55 : 1;
+  const nameDecoration = done ? 'line-through' : 'none';
+  return (
+    <tr style={{
+      background: overlapBg,
+      borderBottom: `1px solid ${T.divider}`,
+      opacity: rowOpacity,
+      transition: 'opacity 120ms ease',
+    }}>
+      <td style={{ padding: '7px 10px', width: 28 }}>
+        <input
+          type="checkbox"
+          checked={!!t.showLabel}
+          onChange={(e) => onToggleShowLabel?.(t.id, e.target.checked)}
+          title="在圖表上顯示此任務標籤"
+          style={{ accentColor: T.iris, cursor: 'pointer' }}
+        />
+      </td>
+      <td style={{ padding: '7px 8px', width: 20 }}>
+        {overlap >= 2 && (
+          <I d={ICON.alert} size={12} style={{ color: overlap >= 3 ? T.danger : T.warn }} />
+        )}
+      </td>
+      <td style={{
+        padding: '7px 8px', fontSize: 12,
+        color: done ? T.textMute : T.text,
+        fontWeight: done ? 400 : 500,
+        textDecoration: nameDecoration,
+      }}>
+        {t.name}
+      </td>
+      <td style={{
+        padding: '7px 8px', width: 50, fontSize: 12, fontFamily: MONO,
+        color: done ? T.textDim : T.text, textAlign: 'center',
+        textDecoration: nameDecoration,
+      }}>
+        {done && <I d={ICON.lock} size={9} style={{ color: T.textFaint, marginRight: 2 }} />}
+        {t.points}
+      </td>
+      <td style={{ padding: '7px 8px', width: 110, fontSize: 12 }}>
+        {t.people ? (
+          <div style={{ display: 'inline-flex', alignItems: 'center', gap: 6 }}>
+            <Avatar name={t.people} size={16} />
+            <span>{t.people}</span>
+          </div>
+        ) : (
+          <span style={{ color: T.textDim }}>—</span>
+        )}
+      </td>
+      <td style={{ padding: '7px 8px', width: 72, fontFamily: MONO, fontSize: 11, color: T.textMute }}>
+        {short(t.addedDate)}
+      </td>
+      <td style={{ padding: '7px 8px', width: 130 }}>
+        <ProgressCell
+          value={t.progress ?? 0}
+          done={done}
+          onCommit={(v) => onUpdateProgress?.(t.id, v)}
+        />
+      </td>
+      <td style={{ padding: '7px 8px', width: 170, fontFamily: MONO, fontSize: 11 }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 4, color: T.iris }}>
+          <span>{short(t.expectedStart) || '—'}</span>
+          <span style={{ color: T.textFaint }}>→</span>
+          <span>{short(t.expectedEnd) || '—'}</span>
+          {(t.expectedStart || t.expectedEnd) && (
+            <span style={{
+              marginLeft: 'auto', fontSize: 9.5, color: T.textDim,
+              border: `1px solid ${T.border}`, background: T.surface2,
+              padding: '1px 4px', borderRadius: 3, letterSpacing: 0.3,
+            }}>
+              {weekCodeRange(t.expectedStart, t.expectedEnd || t.expectedStart)}
+            </span>
+          )}
+        </div>
+      </td>
+      <td style={{ padding: '7px 8px', width: 170, fontFamily: MONO, fontSize: 11 }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 4, color: t.actualStart ? T.green : T.textFaint }}>
+          <span>{short(t.actualStart) || '—'}</span>
+          <span style={{ color: T.textFaint }}>→</span>
+          <span style={{ fontWeight: t.actualEnd ? 600 : 400 }}>{short(t.actualEnd) || '—'}</span>
+          {t.actualStart && (
+            <span style={{
+              marginLeft: 'auto', fontSize: 9.5, color: T.textDim,
+              border: `1px solid ${T.border}`, background: T.surface2,
+              padding: '1px 4px', borderRadius: 3, letterSpacing: 0.3,
+            }}>
+              {weekCodeRange(t.actualStart, t.actualEnd || t.actualStart)}
+            </span>
+          )}
+        </div>
+      </td>
+      <td style={{ padding: '7px 8px', width: 60, textAlign: 'right', color: T.textDim }}>
+        <button
+          onClick={() => onSelectTask?.(t)}
+          title="View task details"
+          style={{
+            width: 22, height: 22, border: 'none', background: 'transparent',
+            color: T.textDim, cursor: 'pointer', borderRadius: 3,
+            display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
+          }}
+          onMouseOver={(e) => { e.currentTarget.style.color = T.text; e.currentTarget.style.background = T.surface2; }}
+          onMouseOut={(e) => { e.currentTarget.style.color = T.textDim; e.currentTarget.style.background = 'transparent'; }}
+        >
+          <I d={ICON.more} size={14} />
+        </button>
+      </td>
+    </tr>
+  );
+}
+
+export function TaskTable({ tasks, onUpdateProgress, onToggleShowLabel, onSelectTask, onAddTask, onToggleHideDone, hideDone }) {
+  const visible = hideDone ? tasks.filter(t => !t.actualEnd) : tasks;
+  return (
+    <div style={{ background: T.surface, border: `1px solid ${T.border}`, borderRadius: 6 }}>
+      <div style={{
+        display: 'flex', justifyContent: 'space-between', alignItems: 'center',
+        padding: '10px 14px', borderBottom: `1px solid ${T.divider}`,
+      }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          <h2 style={{ fontSize: 13, fontWeight: 600, margin: 0 }}>Tasks</h2>
+          <span style={{ fontSize: 11, color: T.textDim, fontFamily: MONO }}>{visible.length}</span>
+        </div>
+        <div style={{ display: 'flex', gap: 4, alignItems: 'center' }}>
+          <Btn variant="ghost" icon="eye" onClick={onToggleHideDone}>
+            {hideDone ? 'Show done' : 'Hide done'}
+          </Btn>
+          <Btn variant="ghost" icon="people">All people</Btn>
+          <div style={{ width: 1, height: 16, background: T.border, margin: '0 4px' }} />
+          <Btn variant="subtle" icon="plus" onClick={onAddTask}>Add task</Btn>
+        </div>
+      </div>
+      <div style={{ overflow: 'auto' }}>
+        <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+          <thead>
+            <tr style={{
+              fontSize: 10, color: T.textDim, textTransform: 'uppercase',
+              letterSpacing: 0.5, background: T.surface2,
+            }}>
+              <th style={th} />
+              <th style={th} />
+              <th style={{ ...th, textAlign: 'left' }}>Name</th>
+              <th style={{ ...th, textAlign: 'center' }}>Pts</th>
+              <th style={{ ...th, textAlign: 'left' }}>Assignee</th>
+              <th style={{ ...th, textAlign: 'left' }}>Added</th>
+              <th style={{ ...th, textAlign: 'left' }}>Progress</th>
+              <th style={{ ...th, textAlign: 'left', color: T.iris }}>Planned</th>
+              <th style={{ ...th, textAlign: 'left', color: T.green }}>Actual</th>
+              <th style={th} />
+            </tr>
+          </thead>
+          <tbody>
+            {visible.length === 0 ? (
+              <tr>
+                <td colSpan={10} style={{ padding: 24, textAlign: 'center', color: T.textDim, fontSize: 12 }}>
+                  沒有任務 — 點「Add task」建立第一個
+                </td>
+              </tr>
+            ) : (
+              visible.map(t => (
+                <TaskRow
+                  key={t.id}
+                  t={t}
+                  onUpdateProgress={onUpdateProgress}
+                  onToggleShowLabel={onToggleShowLabel}
+                  onSelectTask={onSelectTask}
+                />
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+const th = { padding: '7px 8px', fontWeight: 500 };

--- a/src/components/burnup/burnupMath.js
+++ b/src/components/burnup/burnupMath.js
@@ -1,0 +1,186 @@
+// Pure helpers for computing Burnup chart and KPI values.
+// Shared between KpiStrip, BurnupChart, and the task table.
+
+export function addDays(dateStr, n) {
+  const d = new Date(dateStr);
+  d.setDate(d.getDate() + n);
+  return d.toISOString().split('T')[0];
+}
+
+export function getDateRange(start, end) {
+  if (!start || !end) return [];
+  const out = [];
+  let cur = start;
+  while (cur <= end) {
+    out.push(cur);
+    cur = addDays(cur, 1);
+  }
+  return out;
+}
+
+// Total "scope" = sum of points across all tasks.
+export function computeScope(tasks) {
+  return tasks.reduce((s, t) => s + (parseInt(t.points, 10) || 0), 0);
+}
+
+// Weighted progress ratio for a task:
+//   actualEnd set  -> 1 (fully done)
+//   actualStart set but no actualEnd -> partial (todo-based if available, else task.progress)
+//   neither        -> 0
+export function taskProgressRatio(task, todoProgressByTask) {
+  if (task.actualEnd) return 1;
+  if (!task.actualStart) return 0;
+  const tp = todoProgressByTask?.[task.id];
+  if (tp && tp.total > 0) return tp.done / tp.total;
+  const p = Math.max(0, Math.min(100, task.progress ?? 0));
+  return p / 100;
+}
+
+// "Completed" = sum of points weighted by current progress ratio.
+export function computeCompleted(tasks, todoProgressByTask) {
+  return tasks.reduce((s, t) => {
+    const pts = parseInt(t.points, 10) || 0;
+    return s + pts * taskProgressRatio(t, todoProgressByTask);
+  }, 0);
+}
+
+// "Planned today" = sum of points whose expectedEnd has passed.
+export function computePlannedToday(tasks, today) {
+  return tasks.reduce((s, t) => {
+    const pts = parseInt(t.points, 10) || 0;
+    return t.expectedEnd && t.expectedEnd <= today ? s + pts : s;
+  }, 0);
+}
+
+// Velocity = avg completed points/day over last N days.
+// Only counts tasks whose actualEnd falls in that window.
+export function computeVelocity(tasks, today, days = 7) {
+  const start = addDays(today, -days + 1);
+  let total = 0;
+  tasks.forEach(t => {
+    if (t.actualEnd && t.actualEnd >= start && t.actualEnd <= today) {
+      total += parseInt(t.points, 10) || 0;
+    }
+  });
+  return total / days;
+}
+
+// At-risk = count of tasks flagged as warning/danger by assignee overlap.
+export function computeAtRisk(tasks) {
+  return tasks.reduce((n, t) => (t._overlap >= 2 ? n + 1 : n), 0);
+}
+
+// Annotate tasks with an _overlap field = max concurrent same-assignee
+// tasks. Expected and actual windows are evaluated independently so a
+// planning-time collision still raises a warning even if the actual
+// execution didn't end up overlapping (and vice versa).
+export function annotateOverlap(tasks) {
+  const normPerson = (s) => (s || '').trim().toLowerCase();
+  const expectedRange = (t) => t.expectedStart
+    ? { start: t.expectedStart, end: t.expectedEnd || t.expectedStart }
+    : null;
+  const actualRange = (t) => t.actualStart
+    ? { start: t.actualStart, end: t.actualEnd || t.actualStart }
+    : null;
+
+  const countOn = (date, person, pickRange) => {
+    let n = 0;
+    for (const o of tasks) {
+      if (normPerson(o.people) !== person) continue;
+      const or = pickRange(o);
+      if (!or) continue;
+      if (or.start <= date && or.end >= date) n += 1;
+    }
+    return n;
+  };
+
+  return tasks.map(t => {
+    if (!t.people) return { ...t, _overlap: 1 };
+    const person = normPerson(t.people);
+    let maxOverlap = 1;
+
+    const er = expectedRange(t);
+    if (er) {
+      for (let d = er.start; d <= er.end; d = addDays(d, 1)) {
+        const n = countOn(d, person, expectedRange);
+        if (n > maxOverlap) maxOverlap = n;
+      }
+    }
+
+    const ar = actualRange(t);
+    if (ar) {
+      for (let d = ar.start; d <= ar.end; d = addDays(d, 1)) {
+        const n = countOn(d, person, actualRange);
+        if (n > maxOverlap) maxOverlap = n;
+      }
+    }
+
+    return { ...t, _overlap: maxOverlap };
+  });
+}
+
+// Build the burnup series in percent units with today marker.
+// Returns { data: [{d, exp, act, today?}], minDate, maxDate }.
+export function computeBurnupSeries(tasks, todoProgressByTask, today) {
+  if (tasks.length === 0) return { data: [], minDate: '', maxDate: '' };
+
+  let minDate = '9999-12-31';
+  let maxDate = '0000-01-01';
+  tasks.forEach(t => {
+    [t.expectedStart, t.actualStart, t.addedDate].forEach(d => { if (d && d < minDate) minDate = d; });
+    [t.expectedEnd, t.actualEnd].forEach(d => { if (d && d > maxDate) maxDate = d; });
+  });
+  if (minDate === '9999-12-31' || maxDate === '0000-01-01') {
+    return { data: [], minDate: '', maxDate: '' };
+  }
+
+  const timeline = getDateRange(minDate, maxDate);
+  const scope = computeScope(tasks) || 1;
+
+  const data = timeline.map(d => {
+    let expectedCompleted = 0;
+    let actualCompleted = 0;
+    tasks.forEach(t => {
+      const pts = parseInt(t.points, 10) || 0;
+      if (t.expectedEnd && t.expectedEnd <= d) expectedCompleted += pts;
+      if (t.actualEnd && t.actualEnd <= d) {
+        actualCompleted += pts;
+      } else if (t.actualStart && t.actualStart <= d) {
+        const ratio = taskProgressRatio(t, todoProgressByTask);
+        actualCompleted += pts * ratio;
+      }
+    });
+    const point = {
+      d,
+      exp: +((expectedCompleted / scope) * 100).toFixed(1),
+      act: d <= today ? +((actualCompleted / scope) * 100).toFixed(1) : null,
+    };
+    if (d === today) point.today = true;
+    return point;
+  });
+
+  // Annotations: for every task flagged with showLabel, find the target
+  // date (actualEnd > expectedEnd > actualStart > expectedStart > addedDate)
+  // and attach to the corresponding line at that x.
+  const annotations = [];
+  tasks.forEach(t => {
+    if (!t.showLabel) return;
+    const targetDate = t.actualEnd || t.expectedEnd || t.actualStart || t.expectedStart || t.addedDate;
+    if (!targetDate) return;
+    const pt = data.find(d => d.d === targetDate) || data.find(d => d.d > targetDate) || data[data.length - 1];
+    if (!pt) return;
+    const isActual = !!t.actualEnd;
+    const yVal = isActual ? pt.act : pt.exp;
+    if (yVal == null) return;
+    annotations.push({
+      id: t.id,
+      name: t.name,
+      points: t.points,
+      date: pt.d,
+      value: yVal,
+      isActual,
+    });
+  });
+
+  return { data, minDate, maxDate, annotations };
+}

--- a/src/components/burnup/burnupMath.test.js
+++ b/src/components/burnup/burnupMath.test.js
@@ -1,0 +1,233 @@
+import { describe, test, expect } from 'vitest';
+import {
+  addDays,
+  getDateRange,
+  computeScope,
+  taskProgressRatio,
+  computeCompleted,
+  computePlannedToday,
+  computeVelocity,
+  computeAtRisk,
+  annotateOverlap,
+  computeBurnupSeries,
+} from './burnupMath.js';
+
+const task = (overrides = {}) => ({
+  id: 't1',
+  name: 'T',
+  points: 5,
+  people: 'Alice',
+  expectedStart: '2026-04-01',
+  expectedEnd: '2026-04-05',
+  actualStart: '',
+  actualEnd: '',
+  addedDate: '2026-04-01',
+  progress: 0,
+  ...overrides,
+});
+
+describe('addDays / getDateRange', () => {
+  test('addDays forward and backward', () => {
+    expect(addDays('2026-04-19', 1)).toBe('2026-04-20');
+    expect(addDays('2026-04-01', -1)).toBe('2026-03-31');
+  });
+
+  test('getDateRange inclusive', () => {
+    expect(getDateRange('2026-04-18', '2026-04-20'))
+      .toEqual(['2026-04-18', '2026-04-19', '2026-04-20']);
+  });
+
+  test('getDateRange returns [] when endpoints missing', () => {
+    expect(getDateRange('', '2026-04-20')).toEqual([]);
+    expect(getDateRange('2026-04-18', '')).toEqual([]);
+  });
+});
+
+describe('computeScope', () => {
+  test('sums numeric points', () => {
+    expect(computeScope([
+      task({ points: 3 }), task({ points: 5 }), task({ points: 8 }),
+    ])).toBe(16);
+  });
+
+  test('handles string / missing points', () => {
+    expect(computeScope([
+      task({ points: '5' }), task({ points: null }), task({ points: undefined }),
+    ])).toBe(5);
+  });
+});
+
+describe('taskProgressRatio', () => {
+  test('completed task → 1', () => {
+    expect(taskProgressRatio(task({ actualEnd: '2026-04-05' }))).toBe(1);
+  });
+
+  test('not started → 0', () => {
+    expect(taskProgressRatio(task())).toBe(0);
+  });
+
+  test('in-progress uses progress field', () => {
+    expect(taskProgressRatio(task({ actualStart: '2026-04-01', progress: 50 }))).toBe(0.5);
+  });
+
+  test('in-progress prefers todo completion ratio when provided', () => {
+    const todoMap = { t1: { total: 4, done: 3 } };
+    expect(taskProgressRatio(
+      task({ actualStart: '2026-04-01', progress: 50 }), todoMap,
+    )).toBe(0.75);
+  });
+
+  test('out-of-range progress clamps to [0, 100]', () => {
+    expect(taskProgressRatio(task({ actualStart: '2026-04-01', progress: -10 }))).toBe(0);
+    expect(taskProgressRatio(task({ actualStart: '2026-04-01', progress: 150 }))).toBe(1);
+  });
+});
+
+describe('computeCompleted', () => {
+  test('mixed completed + in-progress', () => {
+    const tasks = [
+      task({ id: 'a', points: 4, actualEnd: '2026-04-05' }),                              // full
+      task({ id: 'b', points: 8, actualStart: '2026-04-01', progress: 50 }),              // 4
+      task({ id: 'c', points: 2 }),                                                       // 0
+    ];
+    expect(computeCompleted(tasks)).toBe(8);
+  });
+});
+
+describe('computePlannedToday', () => {
+  test('sums points whose expectedEnd <= today', () => {
+    const tasks = [
+      task({ points: 3, expectedEnd: '2026-04-10' }),
+      task({ points: 5, expectedEnd: '2026-04-20' }), // future
+      task({ points: 2, expectedEnd: '2026-04-19' }), // equal
+    ];
+    expect(computePlannedToday(tasks, '2026-04-19')).toBe(5);
+  });
+});
+
+describe('computeVelocity', () => {
+  test('avg completed points / day across last 7 days', () => {
+    const today = '2026-04-19';
+    const tasks = [
+      task({ points: 7, actualEnd: '2026-04-15' }), // within 7d window
+      task({ points: 2, actualEnd: '2026-04-19' }), // within
+      task({ points: 5, actualEnd: '2026-04-10' }), // outside
+    ];
+    expect(computeVelocity(tasks, today)).toBeCloseTo(9 / 7, 5);
+  });
+});
+
+describe('annotateOverlap', () => {
+  test('no overlap → _overlap = 1', () => {
+    const tasks = annotateOverlap([
+      task({ id: '1', expectedStart: '2026-04-01', expectedEnd: '2026-04-02' }),
+      task({ id: '2', expectedStart: '2026-04-04', expectedEnd: '2026-04-05' }),
+    ]);
+    expect(tasks.every(t => t._overlap === 1)).toBe(true);
+  });
+
+  test('expected-date overlap detected even when actuals differ', () => {
+    const tasks = annotateOverlap([
+      task({ id: '1', expectedStart: '2026-04-01', expectedEnd: '2026-04-05' }),
+      task({ id: '2', expectedStart: '2026-04-03', expectedEnd: '2026-04-07' }),
+    ]);
+    expect(tasks[0]._overlap).toBe(2);
+    expect(tasks[1]._overlap).toBe(2);
+  });
+
+  test('actual-date overlap detected independently', () => {
+    const tasks = annotateOverlap([
+      task({ id: '1', expectedStart: '2026-04-01', expectedEnd: '2026-04-02',
+             actualStart: '2026-04-10', actualEnd: '2026-04-15' }),
+      task({ id: '2', expectedStart: '2026-04-20', expectedEnd: '2026-04-25',
+             actualStart: '2026-04-12', actualEnd: '2026-04-18' }),
+    ]);
+    expect(tasks[0]._overlap).toBe(2);
+    expect(tasks[1]._overlap).toBe(2);
+  });
+
+  test('different assignees never overlap', () => {
+    const tasks = annotateOverlap([
+      task({ id: '1', people: 'Alice', expectedStart: '2026-04-01', expectedEnd: '2026-04-05' }),
+      task({ id: '2', people: 'Bob',   expectedStart: '2026-04-01', expectedEnd: '2026-04-05' }),
+    ]);
+    expect(tasks[0]._overlap).toBe(1);
+    expect(tasks[1]._overlap).toBe(1);
+  });
+
+  test('triple overlap → _overlap = 3', () => {
+    const tasks = annotateOverlap([
+      task({ id: '1', expectedStart: '2026-04-01', expectedEnd: '2026-04-10' }),
+      task({ id: '2', expectedStart: '2026-04-02', expectedEnd: '2026-04-09' }),
+      task({ id: '3', expectedStart: '2026-04-04', expectedEnd: '2026-04-06' }),
+    ]);
+    expect(tasks[0]._overlap).toBe(3);
+  });
+
+  test('unassigned tasks get _overlap = 1', () => {
+    const tasks = annotateOverlap([
+      task({ id: '1', people: '' }),
+      task({ id: '2', people: '' }),
+    ]);
+    expect(tasks.every(t => t._overlap === 1)).toBe(true);
+  });
+});
+
+describe('computeAtRisk', () => {
+  test('counts tasks with _overlap >= 2', () => {
+    const tasks = [
+      { _overlap: 1 }, { _overlap: 2 }, { _overlap: 3 }, { _overlap: 1 },
+    ];
+    expect(computeAtRisk(tasks)).toBe(2);
+  });
+});
+
+describe('computeBurnupSeries', () => {
+  test('returns empty when no tasks', () => {
+    expect(computeBurnupSeries([], {}, '2026-04-19')).toEqual({ data: [], minDate: '', maxDate: '' });
+  });
+
+  test('basic two-task burnup', () => {
+    const tasks = [
+      task({ id: 'a', points: 10, expectedStart: '2026-04-01', expectedEnd: '2026-04-03',
+             actualStart: '2026-04-01', actualEnd: '2026-04-03' }),
+      task({ id: 'b', points: 10, expectedStart: '2026-04-04', expectedEnd: '2026-04-07' }),
+    ];
+    const result = computeBurnupSeries(tasks, {}, '2026-04-05');
+    expect(result.minDate).toBe('2026-04-01');
+    expect(result.maxDate).toBe('2026-04-07');
+    // On 2026-04-03 (task A done): exp=50, act=50
+    const d3 = result.data.find(p => p.d === '2026-04-03');
+    expect(d3.exp).toBeCloseTo(50, 1);
+    expect(d3.act).toBeCloseTo(50, 1);
+    // On 2026-04-05 (today): exp still 50 (b not done), act also 50
+    const d5 = result.data.find(p => p.d === '2026-04-05');
+    expect(d5.exp).toBeCloseTo(50, 1);
+    // On 2026-04-07 (b's expected end): exp should be 100, but act is null (past today)
+    const d7 = result.data.find(p => p.d === '2026-04-07');
+    expect(d7.exp).toBeCloseTo(100, 1);
+    expect(d7.act).toBeNull();
+  });
+
+  test('in-progress task contributes partial points to actual', () => {
+    const tasks = [
+      task({ id: 'a', points: 10, expectedStart: '2026-04-01', expectedEnd: '2026-04-05',
+             actualStart: '2026-04-01', progress: 40 }),
+    ];
+    const result = computeBurnupSeries(tasks, {}, '2026-04-03');
+    const d3 = result.data.find(p => p.d === '2026-04-03');
+    // progress 40% of 10 points → 4 / 10 = 40%
+    expect(d3.act).toBeCloseTo(40, 1);
+  });
+
+  test('annotations emitted for showLabel tasks', () => {
+    const tasks = [
+      task({ id: 'a', points: 3, showLabel: true, expectedEnd: '2026-04-05',
+             actualStart: '2026-04-01', actualEnd: '2026-04-05' }),
+    ];
+    const result = computeBurnupSeries(tasks, {}, '2026-04-06');
+    expect(result.annotations).toHaveLength(1);
+    expect(result.annotations[0].name).toBe('T');
+    expect(result.annotations[0].isActual).toBe(true);
+  });
+});

--- a/src/components/gantt/GanttChart.jsx
+++ b/src/components/gantt/GanttChart.jsx
@@ -1,0 +1,714 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { T, FONT, MONO, weekCode } from '../../design/tokens.js';
+import { Avatar, Badge, Btn, I, ICON } from '../../design/primitives.jsx';
+import { packLanes } from './packLanes.js';
+import { addDays, getDateRange } from '../burnup/burnupMath.js';
+
+// Gantt chart — resource rows with lane-packing + drag/resize + hover tooltip
+// + click-to-inspect popover + zoom + person filter + read-only mode.
+
+const UNASSIGNED = '__unassigned__';
+const LANE_H = 16;
+const LANE_GAP = 2;
+const ACTUAL_GAP = 3;
+const BAND_H = LANE_H * 2 + ACTUAL_GAP;
+
+const ZOOM_PX = { day: 44, week: 14, month: 5 };
+
+function computeTimeline(tasks) {
+  if (tasks.length === 0) return [];
+  let min = '9999-12-31';
+  let max = '0000-01-01';
+  tasks.forEach(t => {
+    [t.expectedStart, t.actualStart, t.addedDate].forEach(d => { if (d && d < min) min = d; });
+    [t.expectedEnd, t.actualEnd].forEach(d => { if (d && d > max) max = d; });
+  });
+  if (min === '9999-12-31' || max === '0000-01-01') return [];
+  return getDateRange(addDays(min, -1), addDays(max, 1));
+}
+
+function dateToIndex(dateStr, days) {
+  if (!dateStr) return null;
+  const i = days.indexOf(dateStr);
+  if (i >= 0) return i;
+  if (days.length > 0 && dateStr < days[0]) return 0;
+  if (days.length > 0 && dateStr > days[days.length - 1]) return days.length - 1;
+  return null;
+}
+
+function groupByAssignee(bars) {
+  const groups = new Map();
+  bars.forEach(b => {
+    const key = b.person || UNASSIGNED;
+    if (!groups.has(key)) groups.set(key, []);
+    groups.get(key).push(b);
+  });
+  return groups;
+}
+
+export function GanttChart({
+  tasks,
+  today,
+  height = 480,
+  readOnly = false,
+  onUpdateTask,
+  onSelectTask,
+}) {
+  const [zoom, setZoom] = useState('day');
+  const [filterPerson, setFilterPerson] = useState('');
+  const [hover, setHover] = useState(null); // {task, x, y}
+  const [selected, setSelected] = useState(null); // {task, x, y}
+  const [drag, setDrag] = useState(null); // {taskId, barType, startX, deltaDays, isResize}
+  const timelineRef = useRef(null);
+  const dragRef = useRef(null);
+
+  const DAY_W = ZOOM_PX[zoom];
+
+  const filteredTasks = useMemo(
+    () => filterPerson
+      ? tasks.filter(t => (t.people?.trim() || '') === filterPerson)
+      : tasks,
+    [tasks, filterPerson]
+  );
+
+  const days = useMemo(() => computeTimeline(filteredTasks), [filteredTasks]);
+  const todayIdx = useMemo(() => today ? dateToIndex(today, days) : null, [today, days]);
+
+  const bars = useMemo(() => filteredTasks.map(t => {
+    let eS = dateToIndex(t.expectedStart, days);
+    let eE = dateToIndex(t.expectedEnd, days);
+    let aS = dateToIndex(t.actualStart, days);
+    let aE = dateToIndex(t.actualEnd, days);
+
+    // apply drag preview (only for the task being dragged)
+    if (drag && drag.taskId === t.id && drag.deltaDays !== 0) {
+      if (drag.barType === 'plan') {
+        if (drag.isResize) {
+          eE = eE != null ? Math.max(eS ?? eE, eE + drag.deltaDays) : eE;
+        } else {
+          eS = eS != null ? eS + drag.deltaDays : eS;
+          eE = eE != null ? eE + drag.deltaDays : eE;
+        }
+      } else if (drag.barType === 'actual') {
+        if (drag.isResize) {
+          aE = aE != null ? Math.max(aS ?? aE, aE + drag.deltaDays) : aE;
+        } else {
+          aS = aS != null ? aS + drag.deltaDays : aS;
+          aE = aE != null ? aE + drag.deltaDays : aE;
+        }
+      }
+    }
+
+    const plannedStart = eS;
+    const plannedEnd = eE != null ? eE + 1 : (eS != null ? eS + 1 : null);
+    const overlapCount = t._overlap || 1;
+    return {
+      id: t.id,
+      raw: t,
+      name: t.name,
+      person: t.people?.trim() || UNASSIGNED,
+      progress: t.progress ?? 0,
+      overlap: overlapCount,
+      done: !!t.actualEnd,
+      eS: plannedStart,
+      eE: plannedEnd,
+      aS,
+      aE: aE != null ? aE + 1 : aS != null ? (todayIdx ?? aS) + 0.3 : null,
+    };
+  }).filter(b => b.eS != null || b.aS != null),
+    [filteredTasks, days, drag, todayIdx]
+  );
+
+  const rowInfo = useMemo(() => {
+    const grouped = groupByAssignee(bars.map(b => ({
+      ...b,
+      start: b.eS ?? b.aS,
+      end: b.eE ?? b.aE ?? (b.eS ?? b.aS) + 1,
+    })));
+    const info = new Map();
+    for (const [person, rowBars] of grouped) {
+      const { lanes, laneCount } = packLanes(rowBars);
+      info.set(person, { bars: rowBars, lanes, laneCount });
+    }
+    return info;
+  }, [bars]);
+
+  const people = useMemo(() => Array.from(rowInfo.keys()).sort((a, b) => {
+    if (a === UNASSIGNED) return 1;
+    if (b === UNASSIGNED) return -1;
+    return a.localeCompare(b);
+  }), [rowInfo]);
+
+  const uniquePeople = useMemo(() => {
+    const set = new Set();
+    tasks.forEach(t => { const p = t.people?.trim(); if (p) set.add(p); });
+    return Array.from(set).sort();
+  }, [tasks]);
+
+  const rowHeightFor = (p) => Math.max(48, 12 + rowInfo.get(p).laneCount * (BAND_H + LANE_GAP));
+
+  // -----------------------------------------------------------------------
+  // Drag handling
+  // -----------------------------------------------------------------------
+  const startDrag = useCallback((e, task, barType, isResize) => {
+    if (readOnly) return;
+    if (e.button !== 0) return;
+    e.preventDefault();
+    e.stopPropagation();
+    dragRef.current = {
+      taskId: task.id,
+      barType,
+      startX: e.clientX,
+      deltaDays: 0,
+      isResize,
+      pxPerDay: DAY_W,
+      raw: task,
+      moved: false,
+    };
+    setDrag({ taskId: task.id, barType, deltaDays: 0, isResize });
+    document.body.style.cursor = isResize ? 'ew-resize' : 'grabbing';
+    document.body.style.userSelect = 'none';
+  }, [readOnly, DAY_W]);
+
+  useEffect(() => {
+    const onMove = (e) => {
+      const s = dragRef.current;
+      if (!s) return;
+      const dpx = e.clientX - s.startX;
+      const deltaDays = Math.round(dpx / s.pxPerDay);
+      if (deltaDays !== s.deltaDays) {
+        s.deltaDays = deltaDays;
+        s.moved = true;
+        setDrag({ taskId: s.taskId, barType: s.barType, deltaDays, isResize: s.isResize });
+      }
+    };
+    const onUp = async () => {
+      const s = dragRef.current;
+      if (!s) return;
+      dragRef.current = null;
+      document.body.style.cursor = '';
+      document.body.style.userSelect = '';
+      if (s.moved && s.deltaDays !== 0 && onUpdateTask) {
+        const task = s.raw;
+        const patch = {};
+        if (s.barType === 'plan') {
+          if (s.isResize) {
+            if (task.expectedEnd) patch.expectedEnd = addDays(task.expectedEnd, s.deltaDays);
+          } else {
+            if (task.expectedStart) patch.expectedStart = addDays(task.expectedStart, s.deltaDays);
+            if (task.expectedEnd) patch.expectedEnd = addDays(task.expectedEnd, s.deltaDays);
+          }
+        } else if (s.barType === 'actual') {
+          if (s.isResize) {
+            if (task.actualEnd) patch.actualEnd = addDays(task.actualEnd, s.deltaDays);
+          } else {
+            if (task.actualStart) patch.actualStart = addDays(task.actualStart, s.deltaDays);
+            if (task.actualEnd) patch.actualEnd = addDays(task.actualEnd, s.deltaDays);
+          }
+        }
+        if (Object.keys(patch).length > 0) await onUpdateTask(task.id, patch);
+      }
+      setDrag(null);
+    };
+    window.addEventListener('mousemove', onMove);
+    window.addEventListener('mouseup', onUp);
+    return () => {
+      window.removeEventListener('mousemove', onMove);
+      window.removeEventListener('mouseup', onUp);
+    };
+  }, [onUpdateTask]);
+
+  // -----------------------------------------------------------------------
+  // Scroll to today
+  // -----------------------------------------------------------------------
+  const scrollToToday = useCallback(() => {
+    const el = timelineRef.current;
+    if (!el || todayIdx == null) return;
+    const x = todayIdx * DAY_W - el.clientWidth / 2;
+    el.scrollTo({ left: Math.max(0, x), behavior: 'smooth' });
+  }, [todayIdx, DAY_W]);
+
+  // Auto scroll to today on first mount when today is within range.
+  useEffect(() => {
+    if (todayIdx == null) return;
+    const el = timelineRef.current;
+    if (!el) return;
+    const x = todayIdx * DAY_W - el.clientWidth / 2;
+    el.scrollLeft = Math.max(0, x);
+    // run once when timeline changes width
+  }, [todayIdx, DAY_W, days.length]);
+
+  // -----------------------------------------------------------------------
+  // Header rendering per zoom level
+  // -----------------------------------------------------------------------
+  const header = useMemo(() => renderHeader(days, zoom, DAY_W, todayIdx), [days, zoom, DAY_W, todayIdx]);
+
+  if (days.length === 0) {
+    return (
+      <div style={{
+        height, background: T.surface, border: `1px solid ${T.border}`, borderRadius: 6,
+        display: 'flex', alignItems: 'center', justifyContent: 'center',
+        color: T.textDim, fontSize: 12,
+      }}>
+        No tasks with dates to display.
+      </div>
+    );
+  }
+
+  return (
+    <div style={{
+      background: T.surface, border: `1px solid ${T.border}`, borderRadius: 6,
+      overflow: 'hidden', height, display: 'flex', flexDirection: 'column', position: 'relative',
+    }}>
+      <div style={{
+        padding: '8px 12px', borderBottom: `1px solid ${T.divider}`,
+        display: 'flex', alignItems: 'center', gap: 8,
+      }}>
+        <div style={{ fontSize: 12, fontWeight: 600 }}>Resource Gantt</div>
+        <Badge tone="neutral" size="sm">by assignee · lane-packed</Badge>
+        {readOnly && (
+          <Badge tone="neutral" size="sm">
+            <I d={ICON.lock} size={9} style={{ marginRight: 3 }} />read-only
+          </Badge>
+        )}
+
+        <div style={{ marginLeft: 'auto', display: 'flex', alignItems: 'center', gap: 6 }}>
+          <select
+            value={filterPerson}
+            onChange={(e) => setFilterPerson(e.target.value)}
+            style={selectStyle}
+            title="Filter by assignee"
+          >
+            <option value="">All people</option>
+            {uniquePeople.map(p => <option key={p} value={p}>{p}</option>)}
+          </select>
+          <div style={{ display: 'flex', gap: 2, border: `1px solid ${T.border}`, borderRadius: 4, padding: 2, background: T.surface2 }}>
+            {['day', 'week', 'month'].map(z => (
+              <button key={z} onClick={() => setZoom(z)} style={{
+                padding: '2px 8px', fontSize: 11,
+                background: zoom === z ? T.surface : 'transparent',
+                color: zoom === z ? T.text : T.textMute,
+                border: 'none', borderRadius: 3, cursor: 'pointer',
+                fontWeight: zoom === z ? 500 : 400, textTransform: 'capitalize',
+                fontFamily: FONT,
+              }}>{z}</button>
+            ))}
+          </div>
+          <Btn variant="ghost" onClick={scrollToToday} title="Scroll timeline to today">Today</Btn>
+        </div>
+      </div>
+
+      <div style={{ display: 'flex', flex: 1, minHeight: 0 }}>
+        {/* Assignee column */}
+        <div style={{
+          width: 160, borderRight: `1px solid ${T.border}`,
+          background: T.bg, flexShrink: 0, overflow: 'hidden',
+        }}>
+          <div style={{
+            height: 44, borderBottom: `1px solid ${T.border}`, padding: '0 12px',
+            display: 'flex', alignItems: 'center',
+            fontSize: 10, color: T.textDim, textTransform: 'uppercase', letterSpacing: 0.6,
+          }}>
+            Assignee
+          </div>
+          {people.map(p => {
+            const { bars: rb, laneCount } = rowInfo.get(p);
+            return (
+              <div key={p} style={{
+                height: rowHeightFor(p), padding: '0 12px',
+                borderBottom: `1px solid ${T.divider}`,
+                display: 'flex', alignItems: 'center', gap: 8,
+              }}>
+                {p !== UNASSIGNED
+                  ? <Avatar name={p} size={20} />
+                  : <div style={{ width: 20, height: 20, borderRadius: 20, border: `1px dashed ${T.borderStrong}` }} />}
+                <div style={{ flex: 1, minWidth: 0 }}>
+                  <div style={{ fontSize: 12, fontWeight: 500, color: p === UNASSIGNED ? T.textDim : T.text }}>
+                    {p === UNASSIGNED ? 'Unassigned' : p}
+                  </div>
+                  <div style={{ fontSize: 10, color: T.textDim, fontFamily: MONO }}>
+                    {rb.length} tasks
+                    {laneCount > 1 && <span style={{ color: T.warn }}> · {laneCount} lanes</span>}
+                  </div>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+
+        {/* Timeline */}
+        <div ref={timelineRef} style={{ flex: 1, overflow: 'auto', minWidth: 0, position: 'relative' }}>
+          <div style={{ minWidth: days.length * DAY_W, position: 'relative' }}>
+            {/* day header */}
+            <div style={{
+              display: 'flex', height: 44, borderBottom: `1px solid ${T.border}`,
+              position: 'sticky', top: 0, background: T.bg, zIndex: 2,
+            }}>
+              {header}
+            </div>
+
+            {/* rows */}
+            {people.map(p => {
+              const rH = rowHeightFor(p);
+              const { bars: rowBars, lanes, laneCount } = rowInfo.get(p);
+              return (
+                <div key={p} style={{
+                  position: 'relative', height: rH,
+                  borderBottom: `1px solid ${T.divider}`,
+                  backgroundImage: DAY_W >= 24
+                    ? `repeating-linear-gradient(90deg, transparent 0 ${DAY_W - 1}px, ${T.divider} ${DAY_W - 1}px ${DAY_W}px)`
+                    : undefined,
+                }}>
+                  {todayIdx != null && (
+                    <div style={{
+                      position: 'absolute', top: 0, bottom: 0,
+                      left: todayIdx * DAY_W + DAY_W / 2, width: 1,
+                      borderLeft: `1px dashed ${T.today}`, pointerEvents: 'none',
+                    }} />
+                  )}
+                  {rowBars.map((b, i) => {
+                    const lane = lanes[i];
+                    const top = 6 + lane * (BAND_H + LANE_GAP);
+                    const isBeingDragged = drag?.taskId === b.id;
+                    const overlapStyle = getOverlapStyle(b.overlap);
+                    const plannedBar = (b.eS != null && b.eE != null) && (
+                      <div
+                        key={`p${b.id}`}
+                        onMouseDown={(e) => startDrag(e, b.raw, 'plan', false)}
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          if (dragRef.current) return;
+                          setSelected({ task: b.raw, x: e.clientX, y: e.clientY });
+                          onSelectTask?.(b.raw);
+                        }}
+                        onMouseMove={(e) => { if (!drag) setHover({ task: b.raw, x: e.clientX, y: e.clientY, type: 'plan' }); }}
+                        onMouseLeave={() => setHover(null)}
+                        style={{
+                          position: 'absolute', top, left: b.eS * DAY_W + 3,
+                          width: Math.max(20, (b.eE - b.eS) * DAY_W - 6), height: LANE_H,
+                          background: overlapStyle.bg,
+                          border: `1px solid ${overlapStyle.border}`,
+                          borderRadius: 3, display: 'flex', alignItems: 'center', padding: '0 6px',
+                          fontSize: 10, color: overlapStyle.fg, fontWeight: 500,
+                          whiteSpace: 'nowrap', overflow: 'hidden',
+                          cursor: readOnly ? 'default' : (isBeingDragged && !drag?.isResize) ? 'grabbing' : 'grab',
+                          opacity: isBeingDragged ? 0.85 : 1,
+                          boxShadow: isBeingDragged ? `0 2px 6px rgba(0,0,0,0.15)` : undefined,
+                          userSelect: 'none',
+                        }}
+                      >
+                        {b.overlap >= 2 && <span style={{ marginRight: 3, fontSize: 9 }}>⚠</span>}
+                        {b.name}
+                        {!readOnly && (b.eE - b.eS) * DAY_W >= 24 && (
+                          <div
+                            onMouseDown={(e) => startDrag(e, b.raw, 'plan', true)}
+                            style={{
+                              position: 'absolute', right: 0, top: 0, bottom: 0, width: 5,
+                              cursor: 'ew-resize',
+                            }}
+                          />
+                        )}
+                      </div>
+                    );
+                    const actualBar = (b.aS != null) && (
+                      <div
+                        key={`a${b.id}`}
+                        onMouseDown={(e) => startDrag(e, b.raw, 'actual', false)}
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          if (dragRef.current) return;
+                          setSelected({ task: b.raw, x: e.clientX, y: e.clientY });
+                          onSelectTask?.(b.raw);
+                        }}
+                        onMouseMove={(e) => { if (!drag) setHover({ task: b.raw, x: e.clientX, y: e.clientY, type: 'actual' }); }}
+                        onMouseLeave={() => setHover(null)}
+                        style={{
+                          position: 'absolute', top: top + LANE_H + ACTUAL_GAP,
+                          left: b.aS * DAY_W + 3,
+                          width: Math.max(20, ((b.aE ?? b.aS + 0.3) - b.aS) * DAY_W - 6),
+                          height: LANE_H,
+                          background: b.done
+                            ? T.green
+                            : `repeating-linear-gradient(135deg, ${T.green}, ${T.green} 4px, #68C07F 4px, #68C07F 8px)`,
+                          borderRadius: 3, padding: '0 6px',
+                          display: 'flex', alignItems: 'center',
+                          fontSize: 10, color: '#fff', fontWeight: 500,
+                          whiteSpace: 'nowrap', overflow: 'hidden',
+                          cursor: readOnly ? 'default' : 'grab',
+                          opacity: isBeingDragged ? 0.85 : 1,
+                          boxShadow: isBeingDragged ? `0 2px 6px rgba(0,0,0,0.15)` : undefined,
+                          userSelect: 'none',
+                        }}
+                      >
+                        {b.done ? '✓ done' : `${b.progress}%`}
+                        {!readOnly && b.aE != null && ((b.aE - b.aS) * DAY_W) >= 24 && (
+                          <div
+                            onMouseDown={(e) => startDrag(e, b.raw, 'actual', true)}
+                            style={{
+                              position: 'absolute', right: 0, top: 0, bottom: 0, width: 5,
+                              cursor: 'ew-resize',
+                            }}
+                          />
+                        )}
+                      </div>
+                    );
+                    return (
+                      <React.Fragment key={b.id}>
+                        {plannedBar}
+                        {actualBar}
+                      </React.Fragment>
+                    );
+                  })}
+                  {laneCount > 1 && (
+                    <div style={{
+                      position: 'absolute', right: 6, top: 4,
+                      fontSize: 9, color: T.textDim, fontFamily: MONO,
+                      pointerEvents: 'none',
+                    }}>
+                      {laneCount}L
+                    </div>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      </div>
+
+      {/* Hover tooltip */}
+      {hover && !drag && <HoverTooltip info={hover} />}
+
+      {/* Click popover */}
+      {selected && !drag && (
+        <SelectedPopover info={selected} onClose={() => setSelected(null)} />
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Header per zoom level
+// ---------------------------------------------------------------------------
+function renderHeader(days, zoom, DAY_W, todayIdx) {
+  if (zoom === 'day') {
+    return days.map((d, i) => {
+      const wc = weekCode(d);
+      const prevWc = i > 0 ? weekCode(days[i - 1]) : null;
+      const showWeek = wc !== prevWc;
+      return (
+        <div key={d} style={{
+          width: DAY_W, flexShrink: 0, textAlign: 'center',
+          fontFamily: MONO, padding: '5px 0',
+          borderRight: i < days.length - 1 ? `1px solid ${T.divider}` : 'none',
+          borderLeft: showWeek && i > 0 ? `1px solid ${T.border}` : 'none',
+          position: 'relative',
+        }}>
+          {showWeek && (
+            <div style={{ fontSize: 9, color: T.textDim, letterSpacing: 0.3, lineHeight: 1 }}>
+              {wc}
+            </div>
+          )}
+          <div style={{
+            fontSize: 10,
+            color: i === todayIdx ? T.today : T.textDim,
+            fontWeight: i === todayIdx ? 600 : 400,
+            marginTop: showWeek ? 3 : 14,
+          }}>
+            {d.slice(5)}
+          </div>
+        </div>
+      );
+    });
+  }
+
+  if (zoom === 'week') {
+    // Group indices by ISO week.
+    const groups = [];
+    for (let i = 0; i < days.length; i++) {
+      const wc = weekCode(days[i]);
+      if (groups.length === 0 || groups[groups.length - 1].wc !== wc) {
+        groups.push({ wc, startIdx: i, endIdx: i });
+      } else {
+        groups[groups.length - 1].endIdx = i;
+      }
+    }
+    return groups.map((g) => {
+      const width = (g.endIdx - g.startIdx + 1) * DAY_W;
+      const hasToday = todayIdx != null && todayIdx >= g.startIdx && todayIdx <= g.endIdx;
+      return (
+        <div key={g.wc + g.startIdx} style={{
+          width, flexShrink: 0, textAlign: 'center',
+          fontFamily: MONO, padding: '5px 0',
+          borderRight: `1px solid ${T.border}`,
+        }}>
+          <div style={{ fontSize: 10, color: hasToday ? T.today : T.textDim, fontWeight: hasToday ? 600 : 500 }}>
+            {g.wc}
+          </div>
+          <div style={{ fontSize: 9, color: T.textDim, marginTop: 2 }}>
+            {days[g.startIdx].slice(5)}
+          </div>
+        </div>
+      );
+    });
+  }
+
+  // month
+  const groups = [];
+  for (let i = 0; i < days.length; i++) {
+    const month = days[i].slice(0, 7);
+    if (groups.length === 0 || groups[groups.length - 1].month !== month) {
+      groups.push({ month, startIdx: i, endIdx: i });
+    } else {
+      groups[groups.length - 1].endIdx = i;
+    }
+  }
+  return groups.map((g) => {
+    const width = (g.endIdx - g.startIdx + 1) * DAY_W;
+    const hasToday = todayIdx != null && todayIdx >= g.startIdx && todayIdx <= g.endIdx;
+    return (
+      <div key={g.month} style={{
+        width, flexShrink: 0, textAlign: 'center',
+        fontFamily: MONO, padding: '5px 0',
+        borderRight: `1px solid ${T.border}`,
+      }}>
+        <div style={{ fontSize: 11, color: hasToday ? T.today : T.text, fontWeight: 600 }}>
+          {g.month}
+        </div>
+      </div>
+    );
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tooltip / popover
+// ---------------------------------------------------------------------------
+function HoverTooltip({ info }) {
+  const { task, x, y, type } = info;
+  const isPlan = type === 'plan';
+  const startDate = isPlan ? task.expectedStart : task.actualStart;
+  const endDate = isPlan ? task.expectedEnd : task.actualEnd;
+  return (
+    <div style={{
+      position: 'fixed', left: x + 14, top: y + 14, zIndex: 50,
+      background: T.surface, border: `1px solid ${T.border}`,
+      borderRadius: 6, padding: '8px 10px',
+      fontFamily: FONT, fontSize: 11, pointerEvents: 'none',
+      minWidth: 200, maxWidth: 280,
+      boxShadow: '0 4px 12px rgba(0,0,0,0.08)',
+    }}>
+      <div style={{ fontWeight: 600, fontSize: 12, marginBottom: 4, color: T.text }}>{task.name}</div>
+      <div style={{ color: T.textMute, fontSize: 10, marginBottom: 6 }}>
+        {task.people || 'Unassigned'} · {task.points}pt
+      </div>
+      <Row label={isPlan ? 'Planned' : 'Actual'} color={isPlan ? T.iris : T.green}>
+        {startDate || '—'} <span style={{ color: T.textFaint }}>→</span> {endDate || '—'}
+      </Row>
+      {!isPlan && (
+        <Row label="Progress" color={T.textMute}>
+          {task.actualEnd ? '100% · done' : `${task.progress ?? 0}%`}
+        </Row>
+      )}
+    </div>
+  );
+}
+
+function SelectedPopover({ info, onClose }) {
+  const { task, x, y } = info;
+  return (
+    <>
+      <div
+        onClick={onClose}
+        style={{ position: 'fixed', inset: 0, zIndex: 40 }}
+      />
+      <div style={{
+        position: 'fixed',
+        left: Math.min(x + 14, window.innerWidth - 320),
+        top: Math.min(y + 14, window.innerHeight - 260),
+        zIndex: 50,
+        background: T.surface, border: `1px solid ${T.border}`,
+        borderRadius: 8, padding: 14, width: 300,
+        fontFamily: FONT,
+        boxShadow: '0 8px 24px rgba(0,0,0,0.12)',
+      }}>
+        <div style={{ display: 'flex', alignItems: 'flex-start', gap: 8, marginBottom: 8 }}>
+          <div style={{ flex: 1, minWidth: 0 }}>
+            <div style={{ fontSize: 13, fontWeight: 600, color: T.text, marginBottom: 2 }}>{task.name}</div>
+            <div style={{ fontSize: 11, color: T.textMute }}>
+              {task.people || 'Unassigned'} · {task.points}pt
+            </div>
+          </div>
+          <button
+            onClick={onClose}
+            style={{
+              width: 24, height: 24, border: 'none', background: 'transparent',
+              cursor: 'pointer', color: T.textDim, borderRadius: 4,
+              display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
+            }}
+            title="Close"
+          >
+            <I d={ICON.x} size={14} />
+          </button>
+        </div>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+          <Row label="Planned" color={T.iris}>
+            {task.expectedStart || '—'} <span style={{ color: T.textFaint }}>→</span> {task.expectedEnd || '—'}
+          </Row>
+          <Row label="Actual" color={T.green}>
+            {task.actualStart || '—'} <span style={{ color: T.textFaint }}>→</span> {task.actualEnd || '—'}
+          </Row>
+          <Row label="Progress" color={T.textMute}>
+            {task.actualEnd ? '100% · done' : `${task.progress ?? 0}%`}
+          </Row>
+          <Row label="Added" color={T.textMute}>{task.addedDate || '—'}</Row>
+          {(task._overlap || 1) >= 2 && (
+            <Row label="Overlap" color={T.warn}>
+              {task._overlap} concurrent tasks
+            </Row>
+          )}
+        </div>
+      </div>
+    </>
+  );
+}
+
+function Row({ label, color, children }) {
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 6, fontSize: 11 }}>
+      <span style={{
+        fontSize: 10, color: T.textDim, textTransform: 'uppercase',
+        letterSpacing: 0.5, minWidth: 64,
+      }}>{label}</span>
+      <span style={{ color, fontFamily: MONO, fontSize: 11 }}>{children}</span>
+    </div>
+  );
+}
+
+// Tier the overlap visual based on the same-assignee concurrent count.
+// 1 (no overlap) → iris · 2 → amber · 3+ → red.
+function getOverlapStyle(count) {
+  if (count >= 3) {
+    return {
+      bg: `repeating-linear-gradient(135deg, ${T.dangerSoft}, ${T.dangerSoft} 6px, rgba(220,38,38,0.18) 6px, rgba(220,38,38,0.18) 12px)`,
+      border: T.danger,
+      fg: T.danger,
+    };
+  }
+  if (count >= 2) {
+    return {
+      bg: `repeating-linear-gradient(135deg, ${T.warnSoft}, ${T.warnSoft} 6px, rgba(217,119,6,0.22) 6px, rgba(217,119,6,0.22) 12px)`,
+      border: T.warn,
+      fg: T.warn,
+    };
+  }
+  return { bg: T.irisSoft, border: T.irisDim, fg: T.iris };
+}
+
+const selectStyle = {
+  height: 26, padding: '0 22px 0 8px', fontFamily: FONT, fontSize: 11,
+  color: T.text, background: T.surface, border: `1px solid ${T.border}`,
+  borderRadius: 4, cursor: 'pointer', appearance: 'none',
+  backgroundImage: `linear-gradient(45deg, transparent 50%, ${T.textDim} 50%), linear-gradient(135deg, ${T.textDim} 50%, transparent 50%)`,
+  backgroundPosition: `right 9px top 11px, right 5px top 11px`,
+  backgroundSize: '4px 4px, 4px 4px',
+  backgroundRepeat: 'no-repeat',
+};

--- a/src/components/gantt/packLanes.js
+++ b/src/components/gantt/packLanes.js
@@ -1,0 +1,20 @@
+// Pack bars into lanes: each bar gets the lowest lane index where it
+// doesn't overlap any other bar already placed on that lane.
+// Bars carry `start` and `end` indices (day integers). Returns
+// { lanes: number[] (same length as bars), laneCount }.
+
+export function packLanes(bars) {
+  const sorted = bars.map((b, i) => ({ ...b, _i: i })).sort((a, b) => a.start - b.start);
+  const laneEnds = [];
+  const out = bars.map(() => 0);
+  for (const b of sorted) {
+    let lane = laneEnds.findIndex(end => end <= b.start);
+    if (lane === -1) {
+      lane = laneEnds.length;
+      laneEnds.push(0);
+    }
+    laneEnds[lane] = b.end;
+    out[b._i] = lane;
+  }
+  return { lanes: out, laneCount: laneEnds.length };
+}

--- a/src/components/gantt/packLanes.test.js
+++ b/src/components/gantt/packLanes.test.js
@@ -1,0 +1,76 @@
+import { describe, test, expect } from 'vitest';
+import { packLanes } from './packLanes.js';
+
+describe('packLanes', () => {
+  test('empty input', () => {
+    expect(packLanes([])).toEqual({ lanes: [], laneCount: 0 });
+  });
+
+  test('single bar uses lane 0', () => {
+    const result = packLanes([{ start: 0, end: 5 }]);
+    expect(result).toEqual({ lanes: [0], laneCount: 1 });
+  });
+
+  test('non-overlapping bars share lane 0', () => {
+    const bars = [
+      { start: 0, end: 3 },
+      { start: 5, end: 8 },
+      { start: 10, end: 12 },
+    ];
+    expect(packLanes(bars)).toEqual({ lanes: [0, 0, 0], laneCount: 1 });
+  });
+
+  test('two overlapping bars split into lanes 0 and 1', () => {
+    const bars = [
+      { start: 0, end: 5 },
+      { start: 3, end: 7 },
+    ];
+    const result = packLanes(bars);
+    expect(result.laneCount).toBe(2);
+    expect(result.lanes[0]).toBe(0);
+    expect(result.lanes[1]).toBe(1);
+  });
+
+  test('three-way overlap uses three lanes', () => {
+    const bars = [
+      { start: 0, end: 5 },
+      { start: 1, end: 6 },
+      { start: 2, end: 7 },
+    ];
+    expect(packLanes(bars).laneCount).toBe(3);
+  });
+
+  test('bar reuses freed lane', () => {
+    // Bar A occupies 0–5, bar B 1–4, bar C starts at 6 (after A released).
+    const bars = [
+      { start: 0, end: 5 },  // lane 0
+      { start: 1, end: 4 },  // lane 1 (overlap)
+      { start: 6, end: 9 },  // lane 0 again
+    ];
+    const result = packLanes(bars);
+    expect(result.laneCount).toBe(2);
+    expect(result.lanes[0]).toBe(0);
+    expect(result.lanes[1]).toBe(1);
+    expect(result.lanes[2]).toBe(0);
+  });
+
+  test('preserves original ordering in returned lanes array', () => {
+    // Input order: late, early, mid. Returned lanes[i] matches input index i.
+    const bars = [
+      { start: 10, end: 12 }, // index 0
+      { start: 0, end: 3 },   // index 1
+      { start: 5, end: 8 },   // index 2
+    ];
+    const result = packLanes(bars);
+    expect(result.lanes).toEqual([0, 0, 0]);
+  });
+
+  test('touching intervals may share lane (end <= start)', () => {
+    // Our algorithm uses `end <= start` so touching intervals fit the same lane.
+    const bars = [
+      { start: 0, end: 5 },
+      { start: 5, end: 10 },
+    ];
+    expect(packLanes(bars)).toEqual({ lanes: [0, 0], laneCount: 1 });
+  });
+});

--- a/src/components/modals/SearchModal.jsx
+++ b/src/components/modals/SearchModal.jsx
@@ -61,7 +61,18 @@ export function SearchModal({ tasks = [], todos = [], endStatusId, today, onPick
       .map(x => x.item);
   }, [query, corpus, fuse]);
 
-  useEffect(() => { setActive(0); }, [query]);
+  // Reset the highlight when the query changes (render-time sync).
+  const [lastQuery, setLastQuery] = useState(query);
+  if (query !== lastQuery) {
+    setLastQuery(query);
+    setActive(0);
+  }
+
+  const pickItem = (item) => {
+    if (item.kind === 'task') onPickTask?.(item.raw);
+    else onPickTodo?.(item.raw);
+    onClose?.();
+  };
 
   useEffect(() => {
     const onKey = (e) => {
@@ -87,12 +98,6 @@ export function SearchModal({ tasks = [], todos = [], endStatusId, today, onPick
     const el = listRef.current?.querySelector(`[data-idx="${active}"]`);
     el?.scrollIntoView({ block: 'nearest' });
   }, [active]);
-
-  const pickItem = (item) => {
-    if (item.kind === 'task') onPickTask?.(item.raw);
-    else onPickTodo?.(item.raw);
-    onClose?.();
-  };
 
   return (
     <div style={overlay} onClick={onClose}>

--- a/src/components/modals/SearchModal.jsx
+++ b/src/components/modals/SearchModal.jsx
@@ -1,0 +1,202 @@
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import Fuse from 'fuse.js';
+import { T, FONT, MONO } from '../../design/tokens.js';
+import { I, ICON, Badge, Kbd } from '../../design/primitives.jsx';
+
+// Cmd+K search modal. Fuzzy searches tasks + todos + people + tags.
+// Arrow keys to navigate, Enter to open, Esc to close.
+
+export function SearchModal({ tasks = [], todos = [], endStatusId, today, onPickTask, onPickTodo, onClose }) {
+  const [query, setQuery] = useState('');
+  const [active, setActive] = useState(0);
+  const listRef = useRef(null);
+
+  const corpus = useMemo(() => {
+    const rows = [];
+    tasks.forEach(t => rows.push({
+      kind: 'task', id: t.id, raw: t,
+      title: t.name, subtitle: t.people || 'Unassigned',
+      due: t.expectedEnd, points: t.points, done: !!t.actualEnd,
+    }));
+    todos.forEach(t => {
+      const tags = (t.tags || []).join(' ');
+      const done = endStatusId ? t.status === endStatusId : false;
+      rows.push({
+        kind: 'todo', id: t.id, raw: t,
+        title: t.title, subtitle: t.assignee || 'Unassigned',
+        due: t.dueDate, points: null, prio: t.priority, tags,
+        done,
+        over: !done && t.dueDate && t.dueDate < today,
+      });
+    });
+    return rows;
+  }, [tasks, todos, today, endStatusId]);
+
+  // Ranking key: incomplete todos first (0), everything else after (1).
+  // Stable sort preserves Fuse.js relevance order within each bucket.
+  const rankOf = (r) => (r.kind === 'todo' && !r.done) ? 0 : 1;
+
+  const fuse = useMemo(() => new Fuse(corpus, {
+    keys: ['title', 'subtitle', 'tags'],
+    threshold: 0.35,
+    ignoreLocation: true,
+  }), [corpus]);
+
+  const results = useMemo(() => {
+    const q = query.trim();
+    const raw = q
+      ? fuse.search(q).map(r => r.item)
+      : corpus;
+    // Stable sort incomplete todos to the top while preserving fuse's
+    // relevance / original order within each bucket.
+    return raw
+      .map((item, i) => ({ item, i }))
+      .sort((a, b) => {
+        const ra = rankOf(a.item);
+        const rb = rankOf(b.item);
+        if (ra !== rb) return ra - rb;
+        return a.i - b.i;
+      })
+      .slice(0, 30)
+      .map(x => x.item);
+  }, [query, corpus, fuse]);
+
+  useEffect(() => { setActive(0); }, [query]);
+
+  useEffect(() => {
+    const onKey = (e) => {
+      if (e.key === 'Escape') { e.preventDefault(); onClose?.(); return; }
+      if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        setActive(a => Math.min(results.length - 1, a + 1));
+      } else if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        setActive(a => Math.max(0, a - 1));
+      } else if (e.key === 'Enter') {
+        e.preventDefault();
+        const item = results[active];
+        if (item) pickItem(item);
+      }
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [results, active, onClose]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Scroll active item into view
+  useEffect(() => {
+    const el = listRef.current?.querySelector(`[data-idx="${active}"]`);
+    el?.scrollIntoView({ block: 'nearest' });
+  }, [active]);
+
+  const pickItem = (item) => {
+    if (item.kind === 'task') onPickTask?.(item.raw);
+    else onPickTodo?.(item.raw);
+    onClose?.();
+  };
+
+  return (
+    <div style={overlay} onClick={onClose}>
+      <div style={modal} onClick={(e) => e.stopPropagation()}>
+        <div style={{
+          padding: '10px 12px', borderBottom: `1px solid ${T.divider}`,
+          display: 'flex', alignItems: 'center', gap: 8,
+        }}>
+          <I d={ICON.search} size={14} style={{ color: T.textDim }} />
+          <input
+            autoFocus
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="Search tasks, todos, people, tags…"
+            style={{
+              flex: 1, border: 'none', outline: 'none',
+              fontSize: 13, fontFamily: FONT, color: T.text, background: 'transparent',
+            }}
+          />
+          <Kbd>Esc</Kbd>
+        </div>
+        <div ref={listRef} style={{ padding: 6, maxHeight: 360, overflow: 'auto' }}>
+          <div style={{
+            padding: '6px 10px', fontSize: 10, color: T.textDim,
+            textTransform: 'uppercase', letterSpacing: 0.6,
+          }}>
+            {results.length} result{results.length === 1 ? '' : 's'}
+          </div>
+          {results.length === 0 ? (
+            <div style={{ padding: 18, textAlign: 'center', fontSize: 12, color: T.textDim }}>
+              No matches
+            </div>
+          ) : results.map((r, i) => <ResultRow key={`${r.kind}-${r.id}`} r={r} idx={i} active={i === active} today={today}
+            onPick={() => pickItem(r)}
+            onHover={() => setActive(i)}
+          />)}
+        </div>
+        <div style={{
+          padding: '8px 12px', borderTop: `1px solid ${T.divider}`,
+          display: 'flex', gap: 12, fontSize: 10, color: T.textDim,
+        }}>
+          <span style={{ display: 'inline-flex', alignItems: 'center', gap: 4 }}>
+            <Kbd>↑</Kbd><Kbd>↓</Kbd> navigate
+          </span>
+          <span style={{ display: 'inline-flex', alignItems: 'center', gap: 4 }}>
+            <Kbd>↵</Kbd> open
+          </span>
+          <span style={{ marginLeft: 'auto' }}>
+            Fuse.js · tasks · todos · people · tags
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function ResultRow({ r, idx, active, onPick, onHover }) {
+  const icon = r.kind === 'task' ? ICON.trend : ICON.kanban;
+  const prioTone = r.prio === 'high' ? 'danger' : r.prio === 'medium' ? 'warn' : 'neutral';
+  return (
+    <div
+      data-idx={idx}
+      onClick={onPick}
+      onMouseEnter={onHover}
+      style={{
+        padding: '7px 10px', borderRadius: 4, fontSize: 12,
+        background: active ? T.surface2 : 'transparent',
+        display: 'flex', alignItems: 'center', gap: 8,
+        cursor: 'pointer',
+      }}
+    >
+      <I d={icon} size={12} style={{ color: active ? T.text : T.textDim }} />
+      <span style={{
+        flex: 1, minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+        color: r.done ? T.textMute : T.text,
+        textDecoration: r.done ? 'line-through' : 'none',
+      }}>{r.title}</span>
+      <span style={{ fontSize: 10, color: T.textDim, flexShrink: 0 }}>{r.subtitle}</span>
+      {r.prio && <Badge tone={prioTone} size="sm">{r.prio}</Badge>}
+      {r.kind === 'task' && r.points != null && (
+        <span style={{ fontFamily: MONO, fontSize: 10, color: T.textDim }}>{r.points}pt</span>
+      )}
+      {r.due && (
+        <span style={{
+          fontFamily: MONO, fontSize: 10,
+          color: r.over ? T.danger : T.textDim, minWidth: 36, textAlign: 'right',
+        }}>
+          {r.due.slice(5)}
+        </span>
+      )}
+    </div>
+  );
+}
+
+const overlay = {
+  position: 'fixed', inset: 0,
+  background: 'rgba(15,15,15,0.35)',
+  display: 'flex', alignItems: 'flex-start', justifyContent: 'center',
+  padding: '80px 20px 20px', zIndex: 300,
+};
+const modal = {
+  width: 520, maxWidth: '100%',
+  background: T.surface, border: `1px solid ${T.border}`, borderRadius: 8,
+  overflow: 'hidden',
+  boxShadow: '0 12px 40px rgba(0,0,0,0.12)',
+  color: T.text, fontFamily: FONT,
+};

--- a/src/components/modals/SearchModal.test.jsx
+++ b/src/components/modals/SearchModal.test.jsx
@@ -1,0 +1,151 @@
+import React from 'react';
+import { describe, test, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { SearchModal } from './SearchModal.jsx';
+
+const mkTask = (overrides = {}) => ({
+  id: 't1', name: 'API refactor', points: 5, people: 'Alice',
+  expectedEnd: '2026-04-20', actualEnd: '',
+  ...overrides,
+});
+const mkTodo = (overrides = {}) => ({
+  id: 'td1', title: 'Fix login bug', assignee: 'Bob',
+  dueDate: '2026-04-18', priority: 'high', tags: ['ui'],
+  status: 'doing',
+  ...overrides,
+});
+
+describe('SearchModal', () => {
+  test('renders initial corpus (no query)', () => {
+    render(
+      <SearchModal
+        tasks={[mkTask({ name: 'API refactor' })]}
+        todos={[mkTodo({ title: 'Fix login bug' })]}
+        endStatusId="done"
+        today="2026-04-19"
+        onClose={() => {}}
+      />
+    );
+    expect(screen.getByText('API refactor')).toBeInTheDocument();
+    expect(screen.getByText('Fix login bug')).toBeInTheDocument();
+  });
+
+  test('fuzzy-searches by title', () => {
+    render(
+      <SearchModal
+        tasks={[mkTask({ name: 'API refactor' }), mkTask({ id: 't2', name: 'UI spec' })]}
+        todos={[]}
+        endStatusId="done"
+        today="2026-04-19"
+        onClose={() => {}}
+      />
+    );
+    const input = screen.getByPlaceholderText(/Search/);
+    fireEvent.change(input, { target: { value: 'refactor' } });
+    expect(screen.getByText('API refactor')).toBeInTheDocument();
+    expect(screen.queryByText('UI spec')).not.toBeInTheDocument();
+  });
+
+  test('incomplete todos rank above tasks and completed todos', () => {
+    const incomplete = mkTodo({ id: 'td1', title: 'Incomplete todo', status: 'doing' });
+    const completed = mkTodo({ id: 'td2', title: 'Done todo', status: 'done-status-id' });
+    const taskA = mkTask({ id: 'ta', name: 'Task A' });
+    render(
+      <SearchModal
+        tasks={[taskA]}
+        todos={[completed, incomplete]}  // note: incomplete second in source
+        endStatusId="done-status-id"
+        today="2026-04-19"
+        onClose={() => {}}
+      />
+    );
+    // First rendered result should be the incomplete todo regardless of input order.
+    const results = screen.getAllByText(/Incomplete todo|Done todo|Task A/);
+    expect(results[0].textContent).toBe('Incomplete todo');
+  });
+
+  test('Escape triggers onClose', () => {
+    const onClose = vi.fn();
+    render(
+      <SearchModal
+        tasks={[mkTask()]}
+        todos={[]}
+        endStatusId="done"
+        today="2026-04-19"
+        onClose={onClose}
+      />
+    );
+    fireEvent.keyDown(window, { key: 'Escape' });
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  test('Enter on a highlighted task invokes onPickTask', () => {
+    const onPickTask = vi.fn();
+    const onClose = vi.fn();
+    const task = mkTask({ id: 't1', name: 'Only task' });
+    render(
+      <SearchModal
+        tasks={[task]}
+        todos={[]}
+        endStatusId="done"
+        today="2026-04-19"
+        onPickTask={onPickTask}
+        onClose={onClose}
+      />
+    );
+    fireEvent.keyDown(window, { key: 'Enter' });
+    expect(onPickTask).toHaveBeenCalledWith(task);
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  test('Enter on a highlighted todo invokes onPickTodo', () => {
+    const onPickTodo = vi.fn();
+    const todo = mkTodo({ id: 'td1', title: 'Only todo' });
+    render(
+      <SearchModal
+        tasks={[]}
+        todos={[todo]}
+        endStatusId="done"
+        today="2026-04-19"
+        onPickTodo={onPickTodo}
+        onClose={() => {}}
+      />
+    );
+    fireEvent.keyDown(window, { key: 'Enter' });
+    expect(onPickTodo).toHaveBeenCalledWith(todo);
+  });
+
+  test('ArrowDown moves highlight to next item', () => {
+    const onPickTask = vi.fn();
+    render(
+      <SearchModal
+        tasks={[
+          mkTask({ id: 't1', name: 'First' }),
+          mkTask({ id: 't2', name: 'Second' }),
+        ]}
+        todos={[]}
+        endStatusId="done"
+        today="2026-04-19"
+        onPickTask={onPickTask}
+        onClose={() => {}}
+      />
+    );
+    fireEvent.keyDown(window, { key: 'ArrowDown' });
+    fireEvent.keyDown(window, { key: 'Enter' });
+    expect(onPickTask).toHaveBeenCalledWith(expect.objectContaining({ id: 't2' }));
+  });
+
+  test('shows "No matches" when fuse returns zero', () => {
+    render(
+      <SearchModal
+        tasks={[mkTask({ name: 'API refactor' })]}
+        todos={[]}
+        endStatusId="done"
+        today="2026-04-19"
+        onClose={() => {}}
+      />
+    );
+    fireEvent.change(screen.getByPlaceholderText(/Search/), { target: { value: 'zzzzzz' } });
+    expect(screen.getByText(/No matches/)).toBeInTheDocument();
+  });
+});

--- a/src/components/modals/TaskDetailModal.jsx
+++ b/src/components/modals/TaskDetailModal.jsx
@@ -1,0 +1,245 @@
+import React, { useEffect, useMemo } from 'react';
+import { T, FONT, MONO, weekCodeRange } from '../../design/tokens.js';
+import { I, ICON, Avatar, Badge } from '../../design/primitives.jsx';
+
+// Read-only task detail modal. Shown when a task is clicked from
+// Burnup / Gantt. For editing tasks, the main burnup table still
+// owns the inline editing flow.
+
+export function TaskDetailModal({ task, todos = [], statuses = [], onClose }) {
+  useEffect(() => {
+    const onKey = (e) => { if (e.key === 'Escape') onClose?.(); };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [onClose]);
+
+  const linkedTodos = useMemo(
+    () => todos.filter(t => t.linkedTaskId === task?.id),
+    [todos, task]
+  );
+
+  const endStatusId = useMemo(
+    () => statuses.find(s => s.isDefaultEnd)?.id,
+    [statuses]
+  );
+
+  const doneCount = linkedTodos.filter(t => t.status === endStatusId).length;
+  const totalCount = linkedTodos.length;
+  const todoPct = totalCount > 0 ? Math.round((doneCount / totalCount) * 100) : null;
+  const progressPct = todoPct ?? task?.progress ?? 0;
+
+  if (!task) return null;
+
+  const done = !!task.actualEnd;
+  const logs = task.logs || [];
+
+  return (
+    <div style={overlay} onClick={onClose}>
+      <div style={modal} onClick={(e) => e.stopPropagation()}>
+        <header style={{
+          padding: '14px 16px', borderBottom: `1px solid ${T.divider}`,
+          display: 'flex', alignItems: 'flex-start', gap: 10,
+        }}>
+          <Avatar name={task.people || 'Unassigned'} size={28} />
+          <div style={{ flex: 1, minWidth: 0 }}>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: 2, flexWrap: 'wrap' }}>
+              {task.showLabel && <Badge tone="iris" size="sm">in chart</Badge>}
+              {done && <Badge tone="green" size="sm">done</Badge>}
+              <span style={{ fontSize: 10, color: T.textDim, fontFamily: MONO }}>
+                #{task.id.slice(-6)} · {task.points}pt
+              </span>
+            </div>
+            <div style={{ fontSize: 15, fontWeight: 600, wordBreak: 'break-word' }}>{task.name}</div>
+            <div style={{ fontSize: 11, color: T.textMute, marginTop: 2 }}>
+              {task.people || 'Unassigned'}
+              {task.addedDate && <> · added {task.addedDate}</>}
+            </div>
+          </div>
+          <button style={iconBtn} onClick={onClose} title="Close (Esc)">
+            <I d={ICON.x} size={14} />
+          </button>
+        </header>
+
+        <div style={{
+          padding: 16, display: 'flex', flexDirection: 'column', gap: 14,
+          overflow: 'auto', flex: 1, minHeight: 0,
+        }}>
+          {/* Date cards */}
+          <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 8 }}>
+            <DateCard
+              label="Planned"
+              tone={T.iris}
+              soft={T.irisSoft}
+              border="#D7DAFF"
+              start={task.expectedStart}
+              end={task.expectedEnd}
+            />
+            <DateCard
+              label="Actual"
+              tone={T.green}
+              soft={T.greenSoft}
+              border="#C6E5CC"
+              start={task.actualStart}
+              end={task.actualEnd || (task.actualStart ? 'in progress' : null)}
+            />
+          </div>
+
+          {/* Progress */}
+          <div>
+            <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 4 }}>
+              <span style={{ fontSize: 11, fontWeight: 500 }}>Progress</span>
+              <span style={{ fontSize: 11, fontFamily: MONO, color: T.textMute }}>
+                {totalCount > 0 ? `${doneCount}/${totalCount} todos · ` : ''}{progressPct}%
+              </span>
+            </div>
+            <div style={{ height: 6, background: T.surface2, borderRadius: 3, overflow: 'hidden' }}>
+              <div style={{
+                width: `${progressPct}%`, height: '100%',
+                background: done ? T.green : T.iris,
+              }} />
+            </div>
+            {totalCount > 0 && (
+              <div style={{ fontSize: 10, color: T.textDim, marginTop: 4 }}>
+                Auto-derived from linked todos
+              </div>
+            )}
+          </div>
+
+          {/* Linked todos */}
+          {linkedTodos.length > 0 && (
+            <div>
+              <div style={sectionHeader}>
+                Linked todos <Badge tone="neutral" size="sm">{linkedTodos.length}</Badge>
+              </div>
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
+                {linkedTodos.slice(0, 12).map(td => {
+                  const tdDone = td.status === endStatusId;
+                  return (
+                    <div key={td.id} style={{
+                      padding: '5px 8px', display: 'flex', alignItems: 'center', gap: 8,
+                      fontSize: 12, borderRadius: 4,
+                      background: tdDone ? T.surface2 : 'transparent',
+                    }}>
+                      <div style={{
+                        width: 12, height: 12, borderRadius: 3,
+                        border: `1.5px solid ${tdDone ? T.green : T.borderStrong}`,
+                        background: tdDone ? T.green : 'transparent',
+                        display: 'inline-flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0,
+                      }}>
+                        {tdDone && <I d={ICON.check} size={8} style={{ color: '#fff' }} />}
+                      </div>
+                      <span style={{
+                        color: tdDone ? T.textMute : T.text,
+                        textDecoration: tdDone ? 'line-through' : 'none',
+                        flex: 1, minWidth: 0, overflow: 'hidden',
+                        textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+                      }}>{td.title}</span>
+                      {td.assignee && (
+                        <span style={{ fontSize: 10, color: T.textDim }}>{td.assignee}</span>
+                      )}
+                    </div>
+                  );
+                })}
+                {linkedTodos.length > 12 && (
+                  <div style={{ fontSize: 10, color: T.textDim, padding: '4px 8px' }}>
+                    and {linkedTodos.length - 12} more…
+                  </div>
+                )}
+              </div>
+            </div>
+          )}
+
+          {/* Week code row */}
+          {(task.expectedStart || task.actualStart) && (
+            <div style={{ display: 'flex', gap: 12, fontSize: 11, color: T.textMute, flexWrap: 'wrap' }}>
+              {task.expectedStart && (
+                <div>
+                  <span style={sectionLabel}>Planned W-code</span>{' '}
+                  <span style={{ fontFamily: MONO, color: T.iris }}>
+                    {weekCodeRange(task.expectedStart, task.expectedEnd || task.expectedStart)}
+                  </span>
+                </div>
+              )}
+              {task.actualStart && (
+                <div>
+                  <span style={sectionLabel}>Actual W-code</span>{' '}
+                  <span style={{ fontFamily: MONO, color: T.green }}>
+                    {weekCodeRange(task.actualStart, task.actualEnd || task.actualStart)}
+                  </span>
+                </div>
+              )}
+            </div>
+          )}
+
+          {/* Logs */}
+          {logs.length > 0 && (
+            <div>
+              <div style={sectionHeader}>Logs <Badge tone="neutral" size="sm">{logs.length}</Badge></div>
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+                {logs.slice(0, 8).map(l => (
+                  <div key={l.id} style={{
+                    padding: '6px 8px', borderRadius: 4, background: T.surface2,
+                    fontSize: 11, color: T.textMute,
+                  }}>
+                    <div style={{ fontFamily: MONO, fontSize: 10, color: T.textDim, marginBottom: 2 }}>
+                      {l.date}
+                    </div>
+                    <div style={{ color: T.text, wordBreak: 'break-word' }}>{l.content}</div>
+                  </div>
+                ))}
+                {logs.length > 8 && (
+                  <div style={{ fontSize: 10, color: T.textDim, padding: '2px 8px' }}>
+                    and {logs.length - 8} more…
+                  </div>
+                )}
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function DateCard({ label, tone, soft, border, start, end }) {
+  const emptyStyle = { color: T.textFaint };
+  return (
+    <div style={{
+      padding: 10, border: `1px solid ${border}`, borderRadius: 5, background: soft,
+    }}>
+      <div style={{
+        fontSize: 10, color: tone, fontWeight: 600,
+        textTransform: 'uppercase', letterSpacing: 0.5, marginBottom: 4,
+      }}>{label}</div>
+      <div style={{ fontFamily: MONO, fontSize: 12, color: T.text, ...(!start ? emptyStyle : {}) }}>
+        {start ? `${start} → ${end || '—'}` : '—'}
+      </div>
+    </div>
+  );
+}
+
+const sectionHeader = {
+  fontSize: 11, fontWeight: 500, marginBottom: 6,
+  display: 'flex', alignItems: 'center', gap: 6,
+};
+const sectionLabel = {
+  fontSize: 10, color: T.textDim, textTransform: 'uppercase',
+  letterSpacing: 0.5, fontWeight: 600,
+};
+const overlay = {
+  position: 'fixed', inset: 0, background: 'rgba(15,15,15,0.35)',
+  display: 'flex', alignItems: 'center', justifyContent: 'center',
+  zIndex: 200, padding: 20,
+};
+const modal = {
+  background: T.surface, color: T.text, fontFamily: FONT,
+  border: `1px solid ${T.border}`, borderRadius: 8,
+  width: 600, maxWidth: '100%', maxHeight: '90vh',
+  display: 'flex', flexDirection: 'column',
+  boxShadow: '0 12px 36px rgba(0,0,0,0.14)',
+};
+const iconBtn = {
+  width: 26, height: 26, border: 'none', background: 'transparent',
+  color: T.textDim, cursor: 'pointer', borderRadius: 4,
+  display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
+};

--- a/src/components/subs/ActivityComposer.jsx
+++ b/src/components/subs/ActivityComposer.jsx
@@ -1,0 +1,107 @@
+import React, { useState } from 'react';
+import { T, FONT } from '../../design/tokens.js';
+import { Btn } from '../../design/primitives.jsx';
+
+// Composer for posting sub-project events. Three types map directly to
+// the backend's sub_project_events.type column: note / waiting / decision.
+
+const TYPES = [
+  { value: 'note', label: 'Note' },
+  { value: 'waiting', label: 'Waiting' },
+  { value: 'decision', label: 'Decision' },
+];
+
+export function ActivityComposer({ onPost, disabled }) {
+  const [type, setType] = useState('note');
+  const [title, setTitle] = useState('');
+  const [body, setBody] = useState('');
+  const [waitingOn, setWaitingOn] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+
+  const canSubmit = title.trim() && !submitting;
+
+  const reset = () => {
+    setTitle('');
+    setBody('');
+    setWaitingOn('');
+  };
+
+  const submit = async () => {
+    if (!canSubmit) return;
+    setSubmitting(true);
+    const payload = {
+      type, title: title.trim(),
+      body: body.trim() || null,
+      waitingOn: type === 'waiting' ? (waitingOn.trim() || null) : null,
+    };
+    const ok = await onPost?.(payload);
+    setSubmitting(false);
+    if (ok) reset();
+  };
+
+  return (
+    <div style={{
+      marginTop: 10, padding: 10, display: 'flex', flexDirection: 'column', gap: 8,
+      border: `1px solid ${T.border}`, borderRadius: 6, background: T.surface,
+    }}>
+      <div style={{ display: 'flex', gap: 4, alignItems: 'center' }}>
+        {TYPES.map(t => (
+          <button
+            key={t.value}
+            onClick={() => setType(t.value)}
+            disabled={disabled || submitting}
+            style={{
+              padding: '3px 8px', fontSize: 11, fontFamily: FONT, cursor: 'pointer',
+              background: type === t.value ? T.surface2 : 'transparent',
+              color: type === t.value ? T.text : T.textMute,
+              border: `1px solid ${type === t.value ? T.border : 'transparent'}`,
+              borderRadius: 3, fontWeight: type === t.value ? 500 : 400,
+            }}
+          >{t.label}</button>
+        ))}
+        <span style={{ fontSize: 10, color: T.textDim, marginLeft: 'auto' }}>
+          {type === 'waiting' && 'Who are we blocked on?'}
+          {type === 'decision' && 'Record a decision, rationale optional'}
+          {type === 'note' && 'General update or log entry'}
+        </span>
+      </div>
+      <input
+        type="text"
+        value={title}
+        onChange={(e) => setTitle(e.target.value)}
+        placeholder={type === 'waiting' ? 'What are you waiting for?' : type === 'decision' ? 'The decision' : 'Title'}
+        disabled={disabled || submitting}
+        style={input}
+      />
+      {type === 'waiting' && (
+        <input
+          type="text"
+          value={waitingOn}
+          onChange={(e) => setWaitingOn(e.target.value)}
+          placeholder="Waiting on… (e.g. @devops, Alice)"
+          disabled={disabled || submitting}
+          style={input}
+        />
+      )}
+      <textarea
+        rows={2}
+        value={body}
+        onChange={(e) => setBody(e.target.value)}
+        placeholder="Details (optional)…"
+        disabled={disabled || submitting}
+        style={{ ...input, resize: 'vertical', minHeight: 40, fontFamily: FONT }}
+      />
+      <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
+        <Btn variant="iris" icon="send" onClick={submit} disabled={!canSubmit}>
+          {submitting ? 'Posting…' : 'Post'}
+        </Btn>
+      </div>
+    </div>
+  );
+}
+
+const input = {
+  padding: '6px 8px', fontSize: 12, fontFamily: FONT, color: T.text,
+  background: T.surface, border: `1px solid ${T.border}`, borderRadius: 4,
+  outline: 'none', width: '100%', boxSizing: 'border-box',
+};

--- a/src/components/subs/SubProjectCard.jsx
+++ b/src/components/subs/SubProjectCard.jsx
@@ -1,0 +1,98 @@
+import React from 'react';
+import { T, MONO } from '../../design/tokens.js';
+import { I, ICON, Avatar, Badge, Dot } from '../../design/primitives.jsx';
+
+const STATUS_META = {
+  active:    { tone: 'iris',    label: 'Active',    color: (t) => t.iris },
+  paused:    { tone: 'warn',    label: 'Paused',    color: (t) => t.warn },
+  done:      { tone: 'green',   label: 'Done',      color: (t) => t.green },
+  cancelled: { tone: 'neutral', label: 'Cancelled', color: (t) => t.textDim },
+};
+
+const PRIO_META = {
+  high:   { tone: 'danger', label: 'high' },
+  medium: { tone: 'warn',   label: 'medium' },
+  low:    { tone: 'neutral', label: 'low' },
+};
+
+export function SubProjectCard({ sp, selected, onClick, onEdit, onDelete }) {
+  const s = STATUS_META[sp.status] || STATUS_META.active;
+  const p = PRIO_META[sp.priority] || PRIO_META.medium;
+  const waiting = sp.activeWaitingCount || 0;
+  const tasks = (sp.linkedTaskIds || []).length;
+  const tags = Array.isArray(sp.tags) ? sp.tags : [];
+
+  return (
+    <div
+      onClick={onClick}
+      style={{
+        background: T.surface,
+        border: `1px solid ${selected ? T.iris : T.border}`,
+        boxShadow: selected ? `0 0 0 2px ${T.irisSoft}` : 'none',
+        borderRadius: 6, padding: 12,
+        display: 'flex', flexDirection: 'column', gap: 8,
+        cursor: 'pointer',
+        transition: 'border-color 120ms ease, box-shadow 120ms ease',
+      }}
+    >
+      <div style={{ display: 'flex', alignItems: 'flex-start', gap: 8 }}>
+        <Dot color={s.color(T)} />
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: 3, flexWrap: 'wrap' }}>
+            <span style={{ fontSize: 13, fontWeight: 600, wordBreak: 'break-word' }}>{sp.name}</span>
+            <Badge tone={s.tone} size="sm">{s.label}</Badge>
+            <Badge tone={p.tone} size="sm">P · {p.label}</Badge>
+          </div>
+          {sp.description && (
+            <div style={{ fontSize: 11, color: T.textMute, wordBreak: 'break-word' }}>
+              {sp.description}
+            </div>
+          )}
+        </div>
+        <div style={{ display: 'flex', gap: 2, color: T.textDim }}>
+          <button
+            style={iconBtn}
+            onClick={(e) => { e.stopPropagation(); onEdit?.(sp); }}
+            title="Edit"
+          ><I d={ICON.pencil} size={12} /></button>
+          <button
+            style={iconBtn}
+            onClick={(e) => { e.stopPropagation(); onDelete?.(sp); }}
+            title="Delete"
+          ><I d={ICON.trash} size={12} /></button>
+        </div>
+      </div>
+      <div style={{ display: 'flex', gap: 12, fontSize: 11, color: T.textMute, flexWrap: 'wrap' }}>
+        {sp.owner && (
+          <span style={{ display: 'inline-flex', alignItems: 'center', gap: 4 }}>
+            <Avatar name={sp.owner} size={14} />{sp.owner}
+          </span>
+        )}
+        {sp.dueDate && (
+          <span style={{ display: 'inline-flex', alignItems: 'center', gap: 4, fontFamily: MONO }}>
+            <I d={ICON.calendar} size={11} />{sp.dueDate}
+          </span>
+        )}
+        <span style={{ display: 'inline-flex', alignItems: 'center', gap: 4 }}>
+          <I d={ICON.folder} size={11} />{tasks} linked task{tasks === 1 ? '' : 's'}
+        </span>
+        {waiting > 0 && (
+          <span style={{ display: 'inline-flex', alignItems: 'center', gap: 4, color: T.warn }}>
+            <I d={ICON.clock} size={11} />{waiting} waiting
+          </span>
+        )}
+      </div>
+      {tags.length > 0 && (
+        <div style={{ display: 'flex', gap: 4, flexWrap: 'wrap' }}>
+          {tags.map(t => <Badge key={t} tone="neutral" size="sm">#{t}</Badge>)}
+        </div>
+      )}
+    </div>
+  );
+}
+
+const iconBtn = {
+  width: 22, height: 22, border: 'none', background: 'transparent',
+  cursor: 'pointer', color: T.textDim, borderRadius: 3,
+  display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
+};

--- a/src/components/subs/SubProjectFormModal.jsx
+++ b/src/components/subs/SubProjectFormModal.jsx
@@ -1,0 +1,205 @@
+import React, { useEffect, useState } from 'react';
+import { T, FONT } from '../../design/tokens.js';
+import { I, ICON, Btn, Badge } from '../../design/primitives.jsx';
+
+// Minimal modal for creating / editing a sub-project.
+
+export function SubProjectFormModal({ subProject, allTasks, onSave, onClose }) {
+  const isEdit = !!subProject?.id;
+  const [form, setForm] = useState(() => ({
+    name: subProject?.name || '',
+    description: subProject?.description || '',
+    status: subProject?.status || 'active',
+    priority: subProject?.priority || 'medium',
+    owner: subProject?.owner || '',
+    dueDate: subProject?.dueDate || '',
+    tags: subProject?.tags || [],
+    tagInput: '',
+    linkedTaskIds: subProject?.linkedTaskIds || [],
+  }));
+
+  useEffect(() => {
+    const onKey = (e) => { if (e.key === 'Escape') onClose?.(); };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [onClose]);
+
+  const update = (p) => setForm(prev => ({ ...prev, ...p }));
+  const addTag = () => {
+    const v = form.tagInput.trim();
+    if (!v) return;
+    if (!form.tags.includes(v)) update({ tags: [...form.tags, v], tagInput: '' });
+    else update({ tagInput: '' });
+  };
+  const removeTag = (t) => update({ tags: form.tags.filter(x => x !== t) });
+  const toggleTask = (id) => update({
+    linkedTaskIds: form.linkedTaskIds.includes(id)
+      ? form.linkedTaskIds.filter(x => x !== id)
+      : [...form.linkedTaskIds, id],
+  });
+
+  const submit = (e) => {
+    e?.preventDefault();
+    if (!form.name.trim()) return;
+    const payload = {
+      name: form.name.trim(),
+      description: form.description.trim() || null,
+      status: form.status,
+      priority: form.priority,
+      owner: form.owner.trim() || null,
+      dueDate: form.dueDate || null,
+      tags: form.tags,
+      linkedTaskIds: form.linkedTaskIds,
+    };
+    if (isEdit) payload.id = subProject.id;
+    onSave?.(payload);
+  };
+
+  return (
+    <div style={overlay} onClick={onClose}>
+      <div style={modal} onClick={(e) => e.stopPropagation()}>
+        <header style={{
+          display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+          padding: '12px 16px', borderBottom: `1px solid ${T.divider}`,
+        }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+            <div style={{ fontSize: 13, fontWeight: 600 }}>
+              {isEdit ? 'Edit sub-project' : 'New sub-project'}
+            </div>
+            {isEdit && <Badge tone="neutral" size="sm">{subProject.id.slice(-6)}</Badge>}
+          </div>
+          <button style={iconBtn} onClick={onClose}><I d={ICON.x} size={14} /></button>
+        </header>
+        <form onSubmit={submit} style={{ padding: 16, display: 'flex', flexDirection: 'column', gap: 12, overflow: 'auto', flex: 1, minHeight: 0 }}>
+          <Field label="Name" required>
+            <input type="text" autoFocus value={form.name} onChange={(e) => update({ name: e.target.value })} style={{ ...input, fontSize: 14, fontWeight: 500 }} />
+          </Field>
+          <Field label="Description">
+            <textarea rows={2} value={form.description} onChange={(e) => update({ description: e.target.value })} style={{ ...input, resize: 'vertical', minHeight: 44, fontFamily: FONT }} />
+          </Field>
+          <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 10 }}>
+            <Field label="Status">
+              <select value={form.status} onChange={(e) => update({ status: e.target.value })} style={select}>
+                <option value="active">Active</option>
+                <option value="paused">Paused</option>
+                <option value="done">Done</option>
+                <option value="cancelled">Cancelled</option>
+              </select>
+            </Field>
+            <Field label="Priority">
+              <select value={form.priority} onChange={(e) => update({ priority: e.target.value })} style={select}>
+                <option value="high">High</option>
+                <option value="medium">Medium</option>
+                <option value="low">Low</option>
+              </select>
+            </Field>
+          </div>
+          <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 10 }}>
+            <Field label="Owner">
+              <input type="text" value={form.owner} onChange={(e) => update({ owner: e.target.value })} style={input} />
+            </Field>
+            <Field label="Due date">
+              <input type="date" value={form.dueDate} onChange={(e) => update({ dueDate: e.target.value })} style={input} />
+            </Field>
+          </div>
+          <Field label="Tags">
+            <div style={{
+              display: 'flex', flexWrap: 'wrap', gap: 5, padding: 6,
+              border: `1px solid ${T.border}`, borderRadius: 4, background: T.surface, minHeight: 32, alignItems: 'center',
+            }}>
+              {form.tags.map(t => (
+                <span key={t} style={{
+                  display: 'inline-flex', alignItems: 'center', gap: 3,
+                  padding: '2px 6px', background: T.irisSoft, color: T.iris,
+                  fontSize: 11, borderRadius: 3, border: '1px solid #D7DAFF',
+                }}>
+                  #{t}
+                  <button type="button" onClick={() => removeTag(t)} style={{ ...iconBtn, width: 14, height: 14, color: T.iris }}>
+                    <I d={ICON.x} size={9} />
+                  </button>
+                </span>
+              ))}
+              <input
+                type="text" value={form.tagInput}
+                onChange={(e) => update({ tagInput: e.target.value })}
+                onKeyDown={(e) => { if (e.key === 'Enter') { e.preventDefault(); addTag(); } }}
+                placeholder={form.tags.length ? '' : 'Type a tag + Enter'}
+                style={{ border: 'none', outline: 'none', flex: 1, minWidth: 80, fontFamily: FONT, fontSize: 12, background: 'transparent' }}
+              />
+            </div>
+          </Field>
+          {allTasks.length > 0 && (
+            <Field label={`Linked tasks (${form.linkedTaskIds.length})`}>
+              <div style={{
+                maxHeight: 160, overflow: 'auto', border: `1px solid ${T.border}`,
+                borderRadius: 4, padding: 4, display: 'flex', flexDirection: 'column', gap: 2,
+              }}>
+                {allTasks.map(t => (
+                  <label key={t.id} style={{
+                    display: 'flex', alignItems: 'center', gap: 8, padding: '4px 6px',
+                    fontSize: 12, borderRadius: 3, cursor: 'pointer',
+                    background: form.linkedTaskIds.includes(t.id) ? T.irisSoft : 'transparent',
+                  }}>
+                    <input type="checkbox" checked={form.linkedTaskIds.includes(t.id)}
+                      onChange={() => toggleTask(t.id)} style={{ accentColor: T.iris }} />
+                    <span style={{ color: T.text }}>{t.name}</span>
+                    <span style={{ marginLeft: 'auto', color: T.textDim, fontSize: 10 }}>{t.people || '—'}</span>
+                  </label>
+                ))}
+              </div>
+            </Field>
+          )}
+        </form>
+        <footer style={{
+          display: 'flex', justifyContent: 'flex-end', gap: 6, padding: '10px 16px',
+          borderTop: `1px solid ${T.divider}`, background: T.surface2,
+        }}>
+          <Btn variant="ghost" type="button" onClick={onClose}>Cancel</Btn>
+          <Btn variant="primary" type="button" onClick={submit}>{isEdit ? 'Save' : 'Create'}</Btn>
+        </footer>
+      </div>
+    </div>
+  );
+}
+
+function Field({ label, required, children }) {
+  return (
+    <label style={{ display: 'flex', flexDirection: 'column', gap: 4, fontFamily: FONT }}>
+      <span style={{
+        fontSize: 10, color: T.textDim, textTransform: 'uppercase',
+        letterSpacing: 0.5, fontWeight: 600,
+      }}>
+        {label}{required && <span style={{ color: T.danger, marginLeft: 2 }}>*</span>}
+      </span>
+      {children}
+    </label>
+  );
+}
+
+const overlay = {
+  position: 'fixed', inset: 0, background: 'rgba(15,15,15,0.35)',
+  display: 'flex', alignItems: 'center', justifyContent: 'center',
+  zIndex: 200, padding: 20,
+};
+const modal = {
+  background: T.surface, color: T.text, fontFamily: FONT,
+  border: `1px solid ${T.border}`, borderRadius: 8,
+  width: 540, maxWidth: '100%', maxHeight: '90vh',
+  display: 'flex', flexDirection: 'column',
+  boxShadow: '0 12px 36px rgba(0,0,0,0.14)',
+};
+const input = {
+  padding: '6px 8px', fontSize: 12, fontFamily: FONT, color: T.text,
+  background: T.surface, border: `1px solid ${T.border}`, borderRadius: 4, outline: 'none',
+};
+const select = {
+  ...input, cursor: 'pointer', appearance: 'none', paddingRight: 24,
+  backgroundImage: `linear-gradient(45deg, transparent 50%, ${T.textDim} 50%), linear-gradient(135deg, ${T.textDim} 50%, transparent 50%)`,
+  backgroundPosition: `right 10px top 13px, right 6px top 13px`,
+  backgroundSize: '4px 4px, 4px 4px', backgroundRepeat: 'no-repeat',
+};
+const iconBtn = {
+  width: 22, height: 22, border: 'none', background: 'transparent',
+  color: T.textDim, cursor: 'pointer', borderRadius: 3,
+  display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
+};

--- a/src/components/todo/KanbanBoard.jsx
+++ b/src/components/todo/KanbanBoard.jsx
@@ -1,0 +1,358 @@
+import React, { useState } from 'react';
+import { T, FONT, MONO } from '../../design/tokens.js';
+import { I, ICON, Badge, Btn } from '../../design/primitives.jsx';
+import { KanbanCard } from './KanbanCard.jsx';
+
+// Kanban column board with:
+// - card drag-and-drop between columns
+// - column drag-and-drop for reordering
+// - inline rename on column name click
+// - per-column action menu (set default / delete)
+// - "+ new status" tile at end
+
+function ColumnMenu({ status, statuses, onRename, onDelete, onSetDefaultStart, onSetDefaultEnd, onClose }) {
+  const otherStatuses = statuses.filter(s => s.id !== status.id);
+  const [migrateTarget, setMigrateTarget] = useState(otherStatuses[0]?.id || '');
+  const [showDelete, setShowDelete] = useState(false);
+  return (
+    <div style={{
+      position: 'absolute', top: 28, right: 6, zIndex: 10,
+      background: T.surface, border: `1px solid ${T.border}`, borderRadius: 6,
+      padding: 6, minWidth: 180,
+      boxShadow: '0 8px 24px rgba(0,0,0,0.12)',
+      fontFamily: FONT, fontSize: 12,
+    }} onClick={(e) => e.stopPropagation()}>
+      <MenuItem onClick={() => { onRename(); onClose(); }}>
+        <I d={ICON.pencil} size={11} />Rename
+      </MenuItem>
+      {!status.isDefaultStart && (
+        <MenuItem onClick={() => { onSetDefaultStart(); onClose(); }}>
+          <I d={ICON.arrow} size={11} />Set as default start
+        </MenuItem>
+      )}
+      {!status.isDefaultEnd && (
+        <MenuItem onClick={() => { onSetDefaultEnd(); onClose(); }}>
+          <I d={ICON.check} size={11} />Set as end
+        </MenuItem>
+      )}
+      <div style={{ height: 1, background: T.divider, margin: '4px 0' }} />
+      {!showDelete ? (
+        <MenuItem danger onClick={() => setShowDelete(true)}>
+          <I d={ICON.trash} size={11} />Delete column
+        </MenuItem>
+      ) : (
+        <div style={{ padding: '6px 8px', display: 'flex', flexDirection: 'column', gap: 6 }}>
+          <div style={{ fontSize: 11, color: T.textMute }}>
+            Move existing todos to:
+          </div>
+          <select
+            value={migrateTarget}
+            onChange={(e) => setMigrateTarget(e.target.value)}
+            style={{
+              padding: '4px 6px', fontSize: 11, fontFamily: FONT,
+              border: `1px solid ${T.border}`, borderRadius: 3,
+            }}
+          >
+            {otherStatuses.map(s => <option key={s.id} value={s.id}>{s.name}</option>)}
+          </select>
+          <div style={{ display: 'flex', gap: 4 }}>
+            <Btn variant="danger" type="button" onClick={() => { onDelete(migrateTarget); onClose(); }}>
+              Delete
+            </Btn>
+            <Btn variant="ghost" type="button" onClick={() => setShowDelete(false)}>
+              Cancel
+            </Btn>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function MenuItem({ onClick, danger, children }) {
+  return (
+    <button
+      onClick={onClick}
+      style={{
+        width: '100%', textAlign: 'left', padding: '5px 8px',
+        background: 'transparent', border: 'none', borderRadius: 3,
+        cursor: 'pointer', fontFamily: FONT, fontSize: 12,
+        color: danger ? T.danger : T.text,
+        display: 'inline-flex', alignItems: 'center', gap: 8,
+      }}
+      onMouseOver={(e) => { e.currentTarget.style.background = T.surface2; }}
+      onMouseOut={(e) => { e.currentTarget.style.background = 'transparent'; }}
+    >
+      {children}
+    </button>
+  );
+}
+
+function ColumnHeader({
+  status, count, isEditing, editingName, onStartEdit, onCommitEdit, onCancelEdit,
+  onChangeEditingName, menuOpen, onToggleMenu, onDragStart, onDragEnd,
+}) {
+  return (
+    <div style={{
+      padding: '8px 10px', borderBottom: `1px solid ${T.divider}`,
+      display: 'flex', alignItems: 'center', gap: 6, position: 'relative',
+    }}>
+      <span
+        draggable
+        onDragStart={onDragStart}
+        onDragEnd={onDragEnd}
+        style={{ cursor: 'grab', display: 'inline-flex' }}
+        title="Drag to reorder column"
+      >
+        <I d={ICON.grip} size={12} style={{ color: T.textFaint }} />
+      </span>
+      {isEditing ? (
+        <input
+          autoFocus
+          value={editingName}
+          onChange={(e) => onChangeEditingName(e.target.value)}
+          onBlur={onCommitEdit}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') onCommitEdit();
+            if (e.key === 'Escape') onCancelEdit();
+          }}
+          style={{
+            fontSize: 12, fontWeight: 600, color: T.text,
+            background: T.surface, border: `1px solid ${T.iris}`,
+            borderRadius: 3, padding: '1px 4px', outline: 'none',
+            flex: 1, minWidth: 0, fontFamily: FONT,
+          }}
+        />
+      ) : (
+        <button
+          onClick={onStartEdit}
+          style={{
+            background: 'transparent', border: 'none', padding: 0, cursor: 'text',
+            fontSize: 12, fontWeight: 600, color: T.text, textAlign: 'left',
+            fontFamily: FONT,
+          }}
+          title="Click to rename"
+        >
+          {status.name}
+        </button>
+      )}
+      <span style={{ fontSize: 10, color: T.textDim, fontFamily: MONO }}>{count}</span>
+      {status.isDefaultStart && <Badge tone="neutral" size="sm">default</Badge>}
+      {status.isDefaultEnd && <Badge tone="green" size="sm">end</Badge>}
+      <div style={{ marginLeft: 'auto', display: 'flex', gap: 2 }}>
+        <button
+          onClick={(e) => { e.stopPropagation(); onToggleMenu(); }}
+          style={{
+            background: menuOpen ? T.surface2 : 'transparent',
+            border: 'none', cursor: 'pointer', color: T.textDim,
+            width: 20, height: 20, borderRadius: 3,
+            display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
+          }}
+          title="Column actions"
+        >
+          <I d={ICON.more} size={12} />
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function EmptyDrop() {
+  return (
+    <div style={{
+      padding: '24px 10px', textAlign: 'center',
+      border: `1px dashed ${T.border}`, borderRadius: 4,
+      fontSize: 11, color: T.textDim,
+    }}>
+      <I d={ICON.inbox} size={18} style={{ color: T.textFaint, marginBottom: 6 }} />
+      <div>No todos yet</div>
+      <div style={{ fontSize: 10, marginTop: 2 }}>Drop one here</div>
+    </div>
+  );
+}
+
+export function KanbanBoard({
+  statuses,
+  todos,
+  today,
+  taskNameById,
+  subProjectNameById,
+  onMoveTodo,
+  onCardClick,
+  onRenameStatus,
+  onAddStatus,
+  onDeleteStatus,
+  onReorderStatuses,
+  onSetDefaultStart,
+  onSetDefaultEnd,
+}) {
+  const [draggingCardId, setDraggingCardId] = useState(null);
+  const [dragOverStatus, setDragOverStatus] = useState(null);
+  const [editingColumnId, setEditingColumnId] = useState(null);
+  const [editingName, setEditingName] = useState('');
+  const [menuColumnId, setMenuColumnId] = useState(null);
+  const [draggingColumnId, setDraggingColumnId] = useState(null);
+  const [dragOverColumnId, setDragOverColumnId] = useState(null);
+
+  const byStatus = new Map();
+  statuses.forEach(s => byStatus.set(s.id, []));
+  todos.forEach(t => {
+    if (byStatus.has(t.status)) byStatus.get(t.status).push(t);
+  });
+
+  // -- Card DnD ---
+  const onCardDragStart = (e, todo) => {
+    setDraggingCardId(todo.id);
+    e.dataTransfer.effectAllowed = 'move';
+    try { e.dataTransfer.setData('text/plain', todo.id); } catch { /* ignore */ }
+  };
+  const onCardDragEnd = () => {
+    setDraggingCardId(null);
+    setDragOverStatus(null);
+  };
+  const onDragOverColumn = (e, statusId) => {
+    if (draggingCardId) {
+      e.preventDefault();
+      e.dataTransfer.dropEffect = 'move';
+      setDragOverStatus(statusId);
+    } else if (draggingColumnId && draggingColumnId !== statusId) {
+      e.preventDefault();
+      setDragOverColumnId(statusId);
+    }
+  };
+  const onDropColumn = (e, statusId) => {
+    if (draggingCardId) {
+      e.preventDefault();
+      const todoId = draggingCardId || e.dataTransfer.getData('text/plain');
+      setDraggingCardId(null);
+      setDragOverStatus(null);
+      if (!todoId) return;
+      const todo = todos.find(t => t.id === todoId);
+      if (!todo || todo.status === statusId) return;
+      onMoveTodo?.(todoId, statusId);
+    } else if (draggingColumnId) {
+      e.preventDefault();
+      const sourceId = draggingColumnId;
+      setDraggingColumnId(null);
+      setDragOverColumnId(null);
+      if (sourceId === statusId) return;
+      const ordered = [...statuses];
+      const sourceIdx = ordered.findIndex(s => s.id === sourceId);
+      const targetIdx = ordered.findIndex(s => s.id === statusId);
+      if (sourceIdx < 0 || targetIdx < 0) return;
+      const [moved] = ordered.splice(sourceIdx, 1);
+      ordered.splice(targetIdx, 0, moved);
+      onReorderStatuses?.(ordered);
+    }
+  };
+
+  // --- Column rename ---
+  const startEdit = (status) => {
+    setEditingColumnId(status.id);
+    setEditingName(status.name);
+  };
+  const commitEdit = () => {
+    const name = editingName.trim();
+    if (name && name !== statuses.find(s => s.id === editingColumnId)?.name) {
+      onRenameStatus?.(editingColumnId, name);
+    }
+    setEditingColumnId(null);
+  };
+  const cancelEdit = () => setEditingColumnId(null);
+
+  return (
+    <div
+      style={{ flex: 1, display: 'flex', gap: 10, overflow: 'auto', minHeight: 0 }}
+      onClick={() => setMenuColumnId(null)}
+    >
+      {statuses.map(s => {
+        const items = byStatus.get(s.id) || [];
+        const isCardDropTarget = dragOverStatus === s.id && draggingCardId;
+        const isColumnDropTarget = dragOverColumnId === s.id && draggingColumnId;
+        return (
+          <div
+            key={s.id}
+            onDragOver={(e) => onDragOverColumn(e, s.id)}
+            onDrop={(e) => onDropColumn(e, s.id)}
+            onDragLeave={() => { if (draggingColumnId) setDragOverColumnId(null); }}
+            style={{
+              flex: '1 1 0', minWidth: 232, maxWidth: 420,
+              background: T.bg,
+              border: `1px solid ${isCardDropTarget || isColumnDropTarget ? T.iris : T.border}`,
+              boxShadow: isCardDropTarget ? `0 0 0 2px ${T.irisSoft}` : 'none',
+              borderRadius: 6,
+              display: 'flex', flexDirection: 'column', maxHeight: '100%',
+              transition: 'border-color 120ms ease, box-shadow 120ms ease',
+              opacity: draggingColumnId === s.id ? 0.5 : 1,
+              position: 'relative',
+            }}
+          >
+            <ColumnHeader
+              status={s}
+              count={items.length}
+              isEditing={editingColumnId === s.id}
+              editingName={editingName}
+              onChangeEditingName={setEditingName}
+              onStartEdit={() => startEdit(s)}
+              onCommitEdit={commitEdit}
+              onCancelEdit={cancelEdit}
+              menuOpen={menuColumnId === s.id}
+              onToggleMenu={() => setMenuColumnId(prev => prev === s.id ? null : s.id)}
+              onDragStart={() => setDraggingColumnId(s.id)}
+              onDragEnd={() => { setDraggingColumnId(null); setDragOverColumnId(null); }}
+            />
+            {menuColumnId === s.id && (
+              <ColumnMenu
+                status={s}
+                statuses={statuses}
+                onRename={() => startEdit(s)}
+                onDelete={(migrateTo) => onDeleteStatus?.(s.id, migrateTo)}
+                onSetDefaultStart={() => onSetDefaultStart?.(s.id)}
+                onSetDefaultEnd={() => onSetDefaultEnd?.(s.id)}
+                onClose={() => setMenuColumnId(null)}
+              />
+            )}
+            <div style={{
+              padding: 8, display: 'flex', flexDirection: 'column', gap: 6,
+              overflow: 'auto', flex: 1, minHeight: 0,
+            }}>
+              {items.length === 0 ? <EmptyDrop /> : items.map(t => (
+                <KanbanCard
+                  key={t.id}
+                  todo={t}
+                  done={s.isDefaultEnd}
+                  today={today}
+                  linkedTaskName={t.linkedTaskId ? taskNameById?.get?.(t.linkedTaskId) : null}
+                  subProjectName={t.subProjectId ? subProjectNameById?.get?.(t.subProjectId) : null}
+                  onDragStart={(e) => onCardDragStart(e, t)}
+                  onDragEnd={onCardDragEnd}
+                  onClick={() => onCardClick?.(t)}
+                />
+              ))}
+            </div>
+          </div>
+        );
+      })}
+      <button
+        onClick={onAddStatus}
+        style={{
+          flex: '0 0 auto', width: 180, minHeight: 120,
+          background: 'transparent', border: `1px dashed ${T.border}`,
+          borderRadius: 6, cursor: 'pointer',
+          display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
+          gap: 6, fontSize: 12, color: T.textDim, fontFamily: FONT,
+        }}
+        onMouseOver={(e) => {
+          e.currentTarget.style.borderColor = T.borderStrong;
+          e.currentTarget.style.color = T.textMute;
+        }}
+        onMouseOut={(e) => {
+          e.currentTarget.style.borderColor = T.border;
+          e.currentTarget.style.color = T.textDim;
+        }}
+      >
+        <I d={ICON.plus} size={12} />New status
+      </button>
+    </div>
+  );
+}

--- a/src/components/todo/KanbanBoard.test.jsx
+++ b/src/components/todo/KanbanBoard.test.jsx
@@ -1,0 +1,154 @@
+import React from 'react';
+import { describe, test, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { KanbanBoard } from './KanbanBoard.jsx';
+
+const statuses = [
+  { id: 'todo', name: 'To do', sortOrder: 0, isDefaultStart: true, isDefaultEnd: false },
+  { id: 'doing', name: 'In progress', sortOrder: 1, isDefaultStart: false, isDefaultEnd: false },
+  { id: 'done', name: 'Done', sortOrder: 2, isDefaultStart: false, isDefaultEnd: true },
+];
+
+const todos = [
+  { id: 'a', title: 'Card A', status: 'todo', priority: 'medium', tags: [], comments: [] },
+  { id: 'b', title: 'Card B', status: 'doing', priority: 'high', tags: [], comments: [] },
+];
+
+function dataTransfer() {
+  const store = new Map();
+  return {
+    effectAllowed: '',
+    dropEffect: '',
+    setData: (k, v) => store.set(k, String(v)),
+    getData: (k) => store.get(k) ?? '',
+  };
+}
+
+describe('KanbanBoard', () => {
+  test('renders one column per status with counts', () => {
+    render(
+      <KanbanBoard
+        statuses={statuses}
+        todos={todos}
+        today="2026-04-19"
+        onMoveTodo={() => {}}
+      />
+    );
+    expect(screen.getByText('To do')).toBeInTheDocument();
+    expect(screen.getByText('In progress')).toBeInTheDocument();
+    expect(screen.getByText('Done')).toBeInTheDocument();
+    expect(screen.getByText('Card A')).toBeInTheDocument();
+    expect(screen.getByText('Card B')).toBeInTheDocument();
+  });
+
+  test('drop marks "default" / "end" badges on the right columns', () => {
+    render(
+      <KanbanBoard statuses={statuses} todos={todos} today="2026-04-19" onMoveTodo={() => {}} />
+    );
+    expect(screen.getByText('default')).toBeInTheDocument();
+    expect(screen.getByText('end')).toBeInTheDocument();
+  });
+
+  test('dragging a card onto a different column calls onMoveTodo(id, status)', () => {
+    const onMove = vi.fn();
+    render(
+      <KanbanBoard statuses={statuses} todos={todos} today="2026-04-19" onMoveTodo={onMove} />
+    );
+    const card = screen.getByText('Card A').closest('[draggable]');
+    const doneColumn = screen.getByText('Done').closest('[style*="border-radius: 6px"]')
+                    ?? screen.getByText('Done').closest('div');
+
+    const dt = dataTransfer();
+    fireEvent.dragStart(card, { dataTransfer: dt });
+    fireEvent.dragOver(doneColumn, { dataTransfer: dt });
+    fireEvent.drop(doneColumn, { dataTransfer: dt });
+
+    expect(onMove).toHaveBeenCalledWith('a', 'done');
+  });
+
+  test('dropping onto the same column is a no-op', () => {
+    const onMove = vi.fn();
+    render(
+      <KanbanBoard statuses={statuses} todos={todos} today="2026-04-19" onMoveTodo={onMove} />
+    );
+    const card = screen.getByText('Card A').closest('[draggable]');
+    const currentColumn = screen.getByText('To do').closest('div');
+
+    const dt = dataTransfer();
+    fireEvent.dragStart(card, { dataTransfer: dt });
+    fireEvent.dragOver(currentColumn, { dataTransfer: dt });
+    fireEvent.drop(currentColumn, { dataTransfer: dt });
+
+    expect(onMove).not.toHaveBeenCalled();
+  });
+
+  test('clicking a card invokes onCardClick with the todo object', () => {
+    const onClick = vi.fn();
+    render(
+      <KanbanBoard
+        statuses={statuses} todos={todos} today="2026-04-19"
+        onMoveTodo={() => {}} onCardClick={onClick}
+      />
+    );
+    fireEvent.click(screen.getByText('Card A').closest('[draggable]'));
+    expect(onClick).toHaveBeenCalledWith(expect.objectContaining({ id: 'a' }));
+  });
+
+  test('"+New status" tile triggers onAddStatus', () => {
+    const onAdd = vi.fn();
+    render(
+      <KanbanBoard
+        statuses={statuses} todos={todos} today="2026-04-19"
+        onMoveTodo={() => {}} onAddStatus={onAdd}
+      />
+    );
+    fireEvent.click(screen.getByText('New status'));
+    expect(onAdd).toHaveBeenCalled();
+  });
+
+  test('column inline rename commits through onRenameStatus on Enter', () => {
+    const onRename = vi.fn();
+    render(
+      <KanbanBoard
+        statuses={statuses} todos={todos} today="2026-04-19"
+        onMoveTodo={() => {}} onRenameStatus={onRename}
+      />
+    );
+    fireEvent.click(screen.getByText('To do'));
+    const input = screen.getByDisplayValue('To do');
+    fireEvent.change(input, { target: { value: 'Backlog' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+    expect(onRename).toHaveBeenCalledWith('todo', 'Backlog');
+  });
+
+  test('column rename ignored when name unchanged', () => {
+    const onRename = vi.fn();
+    render(
+      <KanbanBoard
+        statuses={statuses} todos={todos} today="2026-04-19"
+        onMoveTodo={() => {}} onRenameStatus={onRename}
+      />
+    );
+    fireEvent.click(screen.getByText('To do'));
+    const input = screen.getByDisplayValue('To do');
+    fireEvent.keyDown(input, { key: 'Enter' });
+    expect(onRename).not.toHaveBeenCalled();
+  });
+
+  test('Escape cancels column rename', () => {
+    const onRename = vi.fn();
+    render(
+      <KanbanBoard
+        statuses={statuses} todos={todos} today="2026-04-19"
+        onMoveTodo={() => {}} onRenameStatus={onRename}
+      />
+    );
+    fireEvent.click(screen.getByText('To do'));
+    const input = screen.getByDisplayValue('To do');
+    fireEvent.change(input, { target: { value: 'Changed' } });
+    fireEvent.keyDown(input, { key: 'Escape' });
+    expect(onRename).not.toHaveBeenCalled();
+    // Still display mode
+    expect(screen.getByText('To do')).toBeInTheDocument();
+  });
+});

--- a/src/components/todo/KanbanCard.jsx
+++ b/src/components/todo/KanbanCard.jsx
@@ -1,0 +1,102 @@
+import React from 'react';
+import { T, MONO } from '../../design/tokens.js';
+import { I, ICON, Avatar, Badge } from '../../design/primitives.jsx';
+
+// Single todo card in the kanban board. Ported from design bundle's
+// TodoCard component and wired to real data.
+
+const PRIO_META = {
+  high:   { tone: 'danger',  label: 'High', bar: T.danger },
+  medium: { tone: 'warn',    label: 'Med',  bar: T.warn },
+  low:    { tone: 'neutral', label: 'Low',  bar: T.textFaint },
+};
+
+const PRIO_ORDER = { high: 0, medium: 1, low: 2 };
+
+function shortDue(d) {
+  return d ? d.slice(5) : '';
+}
+
+export { PRIO_ORDER };
+
+export function KanbanCard({ todo, done, today, linkedTaskName, subProjectName, onDragStart, onDragEnd, onClick }) {
+  const prio = PRIO_META[todo.priority] || PRIO_META.medium;
+  const overdue = todo.dueDate && !done && todo.dueDate < today;
+  const tags = Array.isArray(todo.tags) ? todo.tags : [];
+  const commentCount = (todo.comments || []).length;
+
+  return (
+    <div
+      draggable
+      onDragStart={onDragStart}
+      onDragEnd={onDragEnd}
+      onClick={onClick}
+      style={{
+        background: T.surface,
+        border: `1px solid ${T.border}`,
+        borderRadius: 5,
+        padding: 9,
+        cursor: 'grab',
+        opacity: done ? 0.55 : 1,
+      }}
+    >
+      <div style={{ display: 'flex', alignItems: 'flex-start', gap: 6, marginBottom: 6 }}>
+        <div style={{
+          width: 3, alignSelf: 'stretch', borderRadius: 2,
+          background: prio.bar, marginTop: 1, marginBottom: 1,
+        }} />
+        <div style={{
+          flex: 1, fontSize: 12.5, fontWeight: 500, lineHeight: 1.35,
+          textDecoration: done ? 'line-through' : 'none',
+          color: done ? T.textMute : T.text,
+          wordBreak: 'break-word',
+        }}>
+          {todo.title}
+        </div>
+        <Badge tone={prio.tone} size="sm">{prio.label}</Badge>
+      </div>
+      {(linkedTaskName || subProjectName) && (
+        <div style={{ display: 'flex', gap: 4, marginBottom: 6, flexWrap: 'wrap' }}>
+          {subProjectName && <Badge tone="violet" size="sm">◆ {subProjectName}</Badge>}
+          {linkedTaskName && (
+            <Badge tone="neutral" size="sm">
+              <I d={ICON.link} size={9} />
+              {linkedTaskName}
+            </Badge>
+          )}
+        </div>
+      )}
+      <div style={{
+        display: 'flex', alignItems: 'center', gap: 6,
+        fontSize: 11, color: T.textMute,
+      }}>
+        {todo.assignee ? (
+          <div style={{ display: 'inline-flex', alignItems: 'center', gap: 4 }}>
+            <Avatar name={todo.assignee} size={16} />
+          </div>
+        ) : null}
+        {tags[0] && (
+          <span style={{ color: T.textDim, fontSize: 10 }}>
+            #{tags[0]}{tags.length > 1 && ` +${tags.length - 1}`}
+          </span>
+        )}
+        <span style={{ marginLeft: 'auto', display: 'inline-flex', alignItems: 'center', gap: 8 }}>
+          {commentCount > 0 && (
+            <span style={{ display: 'inline-flex', alignItems: 'center', gap: 2, color: T.textDim }}>
+              <I d={ICON.msg} size={10} />{commentCount}
+            </span>
+          )}
+          {todo.dueDate && (
+            <span style={{
+              fontFamily: MONO,
+              color: overdue ? T.danger : T.textMute,
+              fontWeight: overdue ? 600 : 400,
+            }}>
+              {shortDue(todo.dueDate)}
+            </span>
+          )}
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/src/components/todo/TodoFormModal.jsx
+++ b/src/components/todo/TodoFormModal.jsx
@@ -1,0 +1,427 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { T, FONT, MONO } from '../../design/tokens.js';
+import { I, ICON, Avatar, Badge, Btn } from '../../design/primitives.jsx';
+
+// Modal / drawer for creating or editing a todo. Ports the legacy
+// TodoFormModal into the new design system (inline styles + tokens).
+
+const URL_REGEX = /(https?:\/\/[^\s]+)/g;
+
+function renderInline(text) {
+  if (!text) return null;
+  const parts = String(text).split(URL_REGEX);
+  return parts.map((part, i) => i % 2 === 1
+    ? <a key={i} href={part} target="_blank" rel="noopener noreferrer"
+        style={{ color: T.iris, wordBreak: 'break-all' }}>{part}</a>
+    : <React.Fragment key={i}>{part}</React.Fragment>);
+}
+
+export function TodoFormModal({
+  todo,
+  statuses,
+  allTasks,
+  subProjects,
+  allTags,
+  allAssignees,
+  onSave,
+  onDelete,
+  onClose,
+  onCreateComment,
+  onUpdateComment,
+  onDeleteComment,
+}) {
+  const isEdit = !!todo?.id;
+  const startStatus = statuses.find(s => s.isDefaultStart);
+
+  const [form, setForm] = useState(() => ({
+    title: todo?.title || '',
+    status: todo?.status || (startStatus ? startStatus.id : ''),
+    priority: todo?.priority || 'medium',
+    dueDate: todo?.dueDate || '',
+    assignee: todo?.assignee || '',
+    tags: todo?.tags || [],
+    tagInput: '',
+    note: todo?.note || '',
+    linkedTaskId: todo?.linkedTaskId || '',
+    subProjectId: todo?.subProjectId || '',
+  }));
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+  const [commentInput, setCommentInput] = useState('');
+  const [editingCommentId, setEditingCommentId] = useState(null);
+  const [editingCommentContent, setEditingCommentContent] = useState('');
+
+  useEffect(() => {
+    const onKey = (e) => { if (e.key === 'Escape') onClose?.(); };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [onClose]);
+
+  const update = (patch) => setForm(prev => ({ ...prev, ...patch }));
+
+  const addTag = () => {
+    const v = form.tagInput.trim();
+    if (!v) return;
+    if (!form.tags.includes(v)) {
+      setForm(prev => ({ ...prev, tags: [...prev.tags, v], tagInput: '' }));
+    } else {
+      setForm(prev => ({ ...prev, tagInput: '' }));
+    }
+  };
+  const removeTag = (t) => setForm(prev => ({ ...prev, tags: prev.tags.filter(x => x !== t) }));
+
+  const taskOptions = useMemo(() => allTasks.map(t => ({
+    value: t.id, label: t.name,
+  })), [allTasks]);
+
+  const handleSubmit = (e) => {
+    e?.preventDefault();
+    if (!form.title.trim()) return;
+    const payload = {
+      title: form.title.trim(),
+      status: form.status,
+      priority: form.priority,
+      dueDate: form.dueDate || null,
+      assignee: form.assignee || null,
+      tags: form.tags,
+      note: form.note || null,
+      linkedTaskId: form.linkedTaskId || null,
+      subProjectId: form.subProjectId || null,
+    };
+    if (isEdit) payload.id = todo.id;
+    onSave?.(payload);
+  };
+
+  const comments = (todo && todo.comments) || [];
+
+  return (
+    <div style={overlay} onClick={onClose}>
+      <div style={modal} onClick={(e) => e.stopPropagation()}>
+        <header style={{
+          display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+          padding: '12px 16px', borderBottom: `1px solid ${T.divider}`,
+        }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+            <div style={{ fontSize: 13, fontWeight: 600 }}>
+              {isEdit ? 'Edit todo' : 'New todo'}
+            </div>
+            {isEdit && <Badge tone="neutral" size="sm" style={{ fontFamily: MONO }}>{todo.id.slice(-6)}</Badge>}
+          </div>
+          <button style={iconBtn} onClick={onClose} title="Close (Esc)">
+            <I d={ICON.x} size={14} />
+          </button>
+        </header>
+
+        <form onSubmit={handleSubmit} style={{ padding: 16, display: 'flex', flexDirection: 'column', gap: 12, flex: 1, overflow: 'auto', minHeight: 0 }}>
+          {/* Title */}
+          <Field label="Title" required>
+            <input
+              type="text"
+              autoFocus
+              value={form.title}
+              onChange={(e) => update({ title: e.target.value })}
+              placeholder="What needs to get done?"
+              style={{ ...input, fontSize: 14, fontWeight: 500 }}
+            />
+          </Field>
+
+          {/* Row: status + priority */}
+          <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 10 }}>
+            <Field label="Status">
+              <select value={form.status} onChange={(e) => update({ status: e.target.value })} style={select}>
+                {statuses.map(s => <option key={s.id} value={s.id}>{s.name}</option>)}
+              </select>
+            </Field>
+            <Field label="Priority">
+              <select value={form.priority} onChange={(e) => update({ priority: e.target.value })} style={select}>
+                <option value="high">High</option>
+                <option value="medium">Medium</option>
+                <option value="low">Low</option>
+              </select>
+            </Field>
+          </div>
+
+          {/* Row: assignee + due */}
+          <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 10 }}>
+            <Field label="Assignee">
+              <input
+                type="text"
+                list="new-ui-assignee-list"
+                value={form.assignee}
+                onChange={(e) => update({ assignee: e.target.value })}
+                placeholder="Who owns this?"
+                style={input}
+              />
+              <datalist id="new-ui-assignee-list">
+                {allAssignees.map(a => <option key={a} value={a} />)}
+              </datalist>
+            </Field>
+            <Field label="Due date">
+              <input
+                type="date"
+                value={form.dueDate}
+                onChange={(e) => update({ dueDate: e.target.value })}
+                style={input}
+              />
+            </Field>
+          </div>
+
+          {/* Tags */}
+          <Field label="Tags">
+            <div style={{
+              display: 'flex', flexWrap: 'wrap', gap: 5, padding: 6,
+              border: `1px solid ${T.border}`, borderRadius: 4, background: T.surface,
+              minHeight: 32, alignItems: 'center',
+            }}>
+              {form.tags.map(t => (
+                <span key={t} style={{
+                  display: 'inline-flex', alignItems: 'center', gap: 3,
+                  padding: '2px 6px', background: T.irisSoft, color: T.iris,
+                  fontSize: 11, borderRadius: 3, border: `1px solid #D7DAFF`,
+                }}>
+                  #{t}
+                  <button type="button" onClick={() => removeTag(t)} style={{
+                    ...iconBtn, width: 14, height: 14, color: T.iris,
+                  }}><I d={ICON.x} size={9} /></button>
+                </span>
+              ))}
+              <input
+                type="text"
+                value={form.tagInput}
+                onChange={(e) => update({ tagInput: e.target.value })}
+                onKeyDown={(e) => { if (e.key === 'Enter') { e.preventDefault(); addTag(); } }}
+                list="new-ui-tag-list"
+                placeholder={form.tags.length ? '' : 'Type a tag + Enter'}
+                style={{
+                  border: 'none', outline: 'none', flex: 1, minWidth: 80,
+                  fontFamily: FONT, fontSize: 12, background: 'transparent',
+                }}
+              />
+              <datalist id="new-ui-tag-list">
+                {allTags.map(t => <option key={t} value={t} />)}
+              </datalist>
+            </div>
+          </Field>
+
+          {/* Row: sub-project + linked task */}
+          <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 10 }}>
+            <Field label="Sub-project">
+              <select value={form.subProjectId} onChange={(e) => update({ subProjectId: e.target.value })} style={select}>
+                <option value="">—</option>
+                {subProjects.map(s => <option key={s.id} value={s.id}>{s.name}</option>)}
+              </select>
+            </Field>
+            <Field label="Linked task">
+              <select value={form.linkedTaskId} onChange={(e) => update({ linkedTaskId: e.target.value })} style={select}>
+                <option value="">—</option>
+                {taskOptions.map(o => <option key={o.value} value={o.value}>{o.label}</option>)}
+              </select>
+            </Field>
+          </div>
+
+          {/* Note */}
+          <Field label="Notes">
+            <textarea
+              rows={3}
+              value={form.note}
+              onChange={(e) => update({ note: e.target.value })}
+              placeholder="Additional context…"
+              style={{ ...input, resize: 'vertical', minHeight: 60, fontFamily: FONT }}
+            />
+          </Field>
+
+          {/* Comments */}
+          {isEdit && (
+            <Field label="Comments">
+              <div style={{
+                display: 'flex', flexDirection: 'column', gap: 8,
+                border: `1px solid ${T.border}`, borderRadius: 4,
+                background: T.surface, padding: 8, maxHeight: 240, overflow: 'auto',
+              }}>
+                {comments.length === 0 && (
+                  <div style={{ fontSize: 11, color: T.textDim, textAlign: 'center', padding: 8 }}>
+                    No comments yet
+                  </div>
+                )}
+                {comments.map(c => (
+                  <div key={c.id} style={{ display: 'flex', gap: 8, alignItems: 'flex-start' }}>
+                    {c.author ? (
+                      <Avatar name={c.author} size={20} />
+                    ) : (
+                      <div style={{
+                        width: 20, height: 20, borderRadius: 20,
+                        background: T.surface2, color: T.textDim,
+                        border: `1px solid ${T.border}`,
+                        display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
+                        flexShrink: 0,
+                      }} title="Author not recorded">
+                        <I d={ICON.user} size={11} />
+                      </div>
+                    )}
+                    <div style={{ flex: 1, minWidth: 0 }}>
+                      <div style={{ display: 'flex', alignItems: 'baseline', gap: 6, marginBottom: 2 }}>
+                        <span style={{ fontSize: 11, fontWeight: 500, color: c.author ? T.text : T.textDim }}>
+                          {c.author || 'Unknown'}
+                        </span>
+                        <span style={{ fontSize: 10, color: T.textDim }}>
+                          {c.createdAt ? c.createdAt.slice(0, 16).replace('T', ' ') : ''}
+                        </span>
+                        {editingCommentId !== c.id && (
+                          <span style={{ marginLeft: 'auto', display: 'flex', gap: 2 }}>
+                            <button type="button" style={iconBtn} title="Edit" onClick={() => {
+                              setEditingCommentId(c.id);
+                              setEditingCommentContent(c.content);
+                            }}>
+                              <I d={ICON.pencil} size={11} />
+                            </button>
+                            <button type="button" style={iconBtn} title="Delete" onClick={() => onDeleteComment?.(c.id)}>
+                              <I d={ICON.trash} size={11} />
+                            </button>
+                          </span>
+                        )}
+                      </div>
+                      {editingCommentId === c.id ? (
+                        <div style={{ display: 'flex', gap: 6 }}>
+                          <input
+                            value={editingCommentContent}
+                            onChange={(e) => setEditingCommentContent(e.target.value)}
+                            onKeyDown={(e) => {
+                              if (e.key === 'Enter') {
+                                onUpdateComment?.(c.id, editingCommentContent.trim());
+                                setEditingCommentId(null);
+                              }
+                              if (e.key === 'Escape') setEditingCommentId(null);
+                            }}
+                            style={{ ...input, fontSize: 12, flex: 1, minWidth: 0 }}
+                          />
+                          <Btn variant="primary" type="button" onClick={() => {
+                            onUpdateComment?.(c.id, editingCommentContent.trim());
+                            setEditingCommentId(null);
+                          }}>Save</Btn>
+                          <Btn variant="ghost" type="button" onClick={() => setEditingCommentId(null)}>Cancel</Btn>
+                        </div>
+                      ) : (
+                        <div style={{ fontSize: 12, color: T.textMute, lineHeight: 1.5, wordBreak: 'break-word' }}>
+                          {renderInline(c.content)}
+                        </div>
+                      )}
+                    </div>
+                  </div>
+                ))}
+                <div style={{ display: 'flex', gap: 6, paddingTop: 6, borderTop: `1px solid ${T.divider}`, marginTop: 2 }}>
+                  <input
+                    value={commentInput}
+                    onChange={(e) => setCommentInput(e.target.value)}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter' && commentInput.trim()) {
+                        onCreateComment?.(todo.id, commentInput.trim());
+                        setCommentInput('');
+                      }
+                    }}
+                    placeholder="Add a comment…"
+                    style={{ ...input, fontSize: 12, flex: 1, minWidth: 0 }}
+                  />
+                  <Btn
+                    variant="iris"
+                    type="button"
+                    icon="send"
+                    disabled={!commentInput.trim()}
+                    onClick={() => {
+                      if (!commentInput.trim()) return;
+                      onCreateComment?.(todo.id, commentInput.trim());
+                      setCommentInput('');
+                    }}
+                  />
+                </div>
+              </div>
+            </Field>
+          )}
+        </form>
+
+        <footer style={{
+          display: 'flex', justifyContent: 'space-between', alignItems: 'center',
+          padding: '10px 16px', borderTop: `1px solid ${T.divider}`, background: T.surface2,
+        }}>
+          <div>
+            {isEdit && (
+              showDeleteConfirm ? (
+                <div style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
+                  <span style={{ fontSize: 11, color: T.danger }}>Delete this todo?</span>
+                  <Btn
+                    variant="danger"
+                    type="button"
+                    style={{ background: T.danger, color: '#fff', borderColor: T.danger }}
+                    onClick={() => onDelete?.(todo.id)}
+                  >
+                    Delete
+                  </Btn>
+                  <Btn variant="ghost" type="button" onClick={() => setShowDeleteConfirm(false)}>Cancel</Btn>
+                </div>
+              ) : (
+                <Btn
+                  variant="ghost"
+                  type="button"
+                  icon="trash"
+                  onClick={() => setShowDeleteConfirm(true)}
+                  style={{ color: T.danger }}
+                >
+                  Delete
+                </Btn>
+              )
+            )}
+          </div>
+          <div style={{ display: 'flex', gap: 6 }}>
+            <Btn variant="ghost" type="button" onClick={onClose}>Cancel</Btn>
+            <Btn variant="primary" type="button" onClick={handleSubmit}>
+              {isEdit ? 'Save' : 'Create'}
+            </Btn>
+          </div>
+        </footer>
+      </div>
+    </div>
+  );
+}
+
+function Field({ label, required, children }) {
+  return (
+    <label style={{ display: 'flex', flexDirection: 'column', gap: 4, fontFamily: FONT }}>
+      <span style={{
+        fontSize: 10, color: T.textDim, textTransform: 'uppercase',
+        letterSpacing: 0.5, fontWeight: 600,
+      }}>
+        {label}{required && <span style={{ color: T.danger, marginLeft: 2 }}>*</span>}
+      </span>
+      {children}
+    </label>
+  );
+}
+
+const overlay = {
+  position: 'fixed', inset: 0, background: 'rgba(15,15,15,0.35)',
+  display: 'flex', alignItems: 'center', justifyContent: 'center',
+  zIndex: 200, padding: 20,
+};
+const modal = {
+  background: T.surface, color: T.text, fontFamily: FONT,
+  border: `1px solid ${T.border}`, borderRadius: 8,
+  width: 560, maxWidth: '100%', maxHeight: '90vh',
+  display: 'flex', flexDirection: 'column',
+  boxShadow: '0 12px 36px rgba(0,0,0,0.14)',
+};
+const input = {
+  padding: '6px 8px', fontSize: 12, fontFamily: FONT, color: T.text,
+  background: T.surface, border: `1px solid ${T.border}`, borderRadius: 4,
+  outline: 'none',
+};
+const select = {
+  ...input, cursor: 'pointer', appearance: 'none',
+  paddingRight: 24,
+  backgroundImage: `linear-gradient(45deg, transparent 50%, ${T.textDim} 50%), linear-gradient(135deg, ${T.textDim} 50%, transparent 50%)`,
+  backgroundPosition: `right 10px top 13px, right 6px top 13px`,
+  backgroundSize: '4px 4px, 4px 4px',
+  backgroundRepeat: 'no-repeat',
+};
+const iconBtn = {
+  width: 22, height: 22, border: 'none', background: 'transparent',
+  color: T.textDim, cursor: 'pointer', borderRadius: 3,
+  display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
+};

--- a/src/design/formatTime.js
+++ b/src/design/formatTime.js
@@ -1,0 +1,33 @@
+// Relative time formatter with m/h/d granularity.
+// "just now" → "5m ago" → "3h ago" → "2d ago" → "04-15" (date).
+
+// The backend emits ISO strings via `datetime.utcnow().isoformat()`, which
+// omits the timezone suffix. Per ECMAScript, JS then parses them as local
+// time, producing an 8-hour drift for Asia/Taipei users. Normalize the
+// input by appending `Z` if the string carries no explicit timezone.
+function parseIsoAsUtc(iso) {
+  if (!iso) return null;
+  let s = String(iso);
+  const hasTz = /[zZ]$|[+-]\d{2}:?\d{2}$/.test(s);
+  // Only append Z to full datetime strings (must contain a `T`).
+  if (!hasTz && s.includes('T')) s = s + 'Z';
+  const d = new Date(s);
+  return Number.isNaN(d.getTime()) ? null : d;
+}
+
+export function formatRelative(iso) {
+  if (!iso) return '';
+  const d = parseIsoAsUtc(iso);
+  if (!d) return iso;
+  const now = new Date();
+  const diffMs = now - d;
+  if (diffMs < 30_000) return 'just now';
+  const m = Math.floor(diffMs / 60_000);
+  if (m < 60) return `${m}m ago`;
+  const h = Math.floor(m / 60);
+  if (h < 24) return `${h}h ago`;
+  const days = Math.floor(h / 24);
+  if (days === 1) return '昨天';
+  if (days < 7) return `${days}d ago`;
+  return d.toISOString().slice(5, 10);
+}

--- a/src/design/formatTime.test.js
+++ b/src/design/formatTime.test.js
@@ -1,0 +1,59 @@
+import { describe, test, expect, beforeEach, afterEach, vi } from 'vitest';
+import { formatRelative } from './formatTime.js';
+
+describe('formatRelative', () => {
+  beforeEach(() => {
+    // Freeze "now" to 2026-04-19 12:00:00 UTC.
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-04-19T12:00:00Z'));
+  });
+  afterEach(() => vi.useRealTimers());
+
+  test('empty input returns empty string', () => {
+    expect(formatRelative('')).toBe('');
+    expect(formatRelative(null)).toBe('');
+    expect(formatRelative(undefined)).toBe('');
+  });
+
+  test('returns raw string on unparseable input', () => {
+    expect(formatRelative('not-a-date')).toBe('not-a-date');
+  });
+
+  test('just now (< 30 seconds)', () => {
+    expect(formatRelative('2026-04-19T11:59:50Z')).toBe('just now');
+  });
+
+  test('minutes ago', () => {
+    expect(formatRelative('2026-04-19T11:55:00Z')).toBe('5m ago');
+    expect(formatRelative('2026-04-19T11:01:00Z')).toBe('59m ago');
+  });
+
+  test('hours ago', () => {
+    expect(formatRelative('2026-04-19T09:00:00Z')).toBe('3h ago');
+    expect(formatRelative('2026-04-18T13:00:00Z')).toBe('23h ago');
+  });
+
+  test('yesterday', () => {
+    expect(formatRelative('2026-04-18T11:00:00Z')).toBe('昨天');
+  });
+
+  test('N days ago (< 7)', () => {
+    expect(formatRelative('2026-04-16T12:00:00Z')).toBe('3d ago');
+  });
+
+  test('>= 7 days returns MM-DD', () => {
+    expect(formatRelative('2026-04-10T12:00:00Z')).toBe('04-10');
+  });
+
+  test('naive UTC without Z suffix is treated as UTC (no 8-hour drift)', () => {
+    // Backend emits `datetime.utcnow().isoformat()` with no timezone.
+    // If we accidentally parse as local, we'd see "8h ago" in Asia/Taipei.
+    // formatRelative must append Z before parsing.
+    expect(formatRelative('2026-04-19T11:55:00')).toBe('5m ago');
+  });
+
+  test('string with explicit +offset is respected as-is', () => {
+    // 12:00 UTC+8 === 04:00 UTC → 8 hours ago from 12:00 UTC.
+    expect(formatRelative('2026-04-19T12:00:00+08:00')).toBe('8h ago');
+  });
+});

--- a/src/design/layout/Shell.jsx
+++ b/src/design/layout/Shell.jsx
@@ -1,0 +1,193 @@
+// App shell — left sidebar + topbar. Ported from new-burnup-design/project/screens/shell.jsx.
+// Page-agnostic; receives active page key and a project label.
+
+import React from 'react';
+import { T, FONT, MONO } from '../tokens.js';
+import { I, ICON, Avatar, Kbd, Dot } from '../primitives.jsx';
+
+export function Shell({ active = 'burnup', project = 'Untitled', children, onNavigate, user, projects = [], activeProjectId, onSelectProject, onOpenSearch }) {
+  return (
+    <div style={{
+      width: '100%', height: '100vh', background: T.bg, color: T.text,
+      fontFamily: FONT, fontSize: 13, lineHeight: 1.45,
+      display: 'flex', overflow: 'hidden',
+      letterSpacing: -0.01,
+    }}>
+      <Sidebar
+        active={active}
+        onNavigate={onNavigate}
+        user={user}
+        projects={projects}
+        activeProjectId={activeProjectId}
+        onSelectProject={onSelectProject}
+        onOpenSearch={onOpenSearch}
+      />
+      <div style={{ flex: 1, display: 'flex', flexDirection: 'column', overflow: 'hidden', minWidth: 0 }}>
+        <Topbar project={project} active={active} />
+        <div style={{ flex: 1, overflow: 'hidden', minHeight: 0 }}>{children}</div>
+      </div>
+    </div>
+  );
+}
+
+export function Sidebar({ active, onNavigate, user, projects, activeProjectId, onSelectProject, onOpenSearch }) {
+  const items = [
+    { key: 'burnup', label: 'Burnup',       icon: 'trend' },
+    { key: 'gantt',  label: 'Gantt',        icon: 'gantt' },
+    { key: 'todos',  label: 'Todos',        icon: 'kanban' },
+    { key: 'subs',   label: 'Sub-projects', icon: 'merge' },
+    { key: 'merged', label: 'Merged',       icon: 'chart' },
+    { key: 'timelog', label: 'Time log',    icon: 'clock' },
+  ];
+  return (
+    <aside style={{
+      width: 212, flexShrink: 0, background: T.surface,
+      borderRight: `1px solid ${T.border}`,
+      display: 'flex', flexDirection: 'column',
+    }}>
+      <div style={{ padding: '12px 12px 10px', borderBottom: `1px solid ${T.divider}` }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '4px 6px', borderRadius: 4 }}>
+          <div style={{
+            width: 20, height: 20, borderRadius: 4, background: T.text,
+            color: '#fff', fontSize: 11, fontWeight: 600,
+            display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
+          }}>B</div>
+          <div style={{ fontSize: 12, fontWeight: 600, flex: 1 }}>Burnup</div>
+          <I d={ICON.chevD} size={12} style={{ color: T.textDim }} />
+        </div>
+        <button
+          onClick={onOpenSearch}
+          style={{
+            marginTop: 8, display: 'flex', alignItems: 'center', gap: 6,
+            padding: '5px 8px', background: T.surface2, border: `1px solid ${T.border}`,
+            borderRadius: 4, color: T.textDim, fontSize: 12, width: '100%',
+            fontFamily: FONT, cursor: 'pointer',
+          }}
+        >
+          <I d={ICON.search} size={12} />
+          <span>Search…</span>
+          <span style={{ marginLeft: 'auto', display: 'flex', gap: 3 }}>
+            <Kbd>⌘</Kbd><Kbd>K</Kbd>
+          </span>
+        </button>
+      </div>
+
+      <nav style={{ padding: 8, overflow: 'auto', flex: 1, minHeight: 0 }}>
+        <SideGroup title="Workflow">
+          {items.map(it => (
+            <SideItem
+              key={it.key}
+              active={active === it.key}
+              icon={it.icon}
+              label={it.label}
+              onClick={() => onNavigate?.(it.key)}
+            />
+          ))}
+        </SideGroup>
+
+        <SideGroup title="Projects">
+          {projects.length === 0 && (
+            <div style={{ fontSize: 11, color: T.textDim, padding: '4px 8px' }}>—</div>
+          )}
+          {projects.map(p => (
+            <SideProject
+              key={p.id}
+              name={p.name}
+              count={p.count}
+              active={p.id === activeProjectId}
+              onClick={() => onSelectProject?.(p.id)}
+            />
+          ))}
+        </SideGroup>
+      </nav>
+
+      <div style={{
+        marginTop: 'auto', padding: '10px 12px', borderTop: `1px solid ${T.divider}`,
+        display: 'flex', alignItems: 'center', gap: 8,
+      }}>
+        <Avatar name={user?.displayName || user?.username || 'User'} size={22} />
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <div style={{ fontSize: 12, fontWeight: 500, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+            {user?.displayName || user?.username || 'Guest'}
+          </div>
+          <div style={{ fontSize: 10, color: T.textDim }}>{user?.role || 'viewer'}</div>
+        </div>
+        <I d={ICON.settings} size={14} style={{ color: T.textDim }} />
+      </div>
+    </aside>
+  );
+}
+
+function SideGroup({ title, children }) {
+  return (
+    <div style={{ marginBottom: 14 }}>
+      <div style={{
+        display: 'flex', justifyContent: 'space-between', alignItems: 'center',
+        padding: '4px 8px', fontSize: 10, fontWeight: 600,
+        color: T.textDim, textTransform: 'uppercase', letterSpacing: 0.6,
+      }}>
+        <span>{title}</span>
+      </div>
+      <div>{children}</div>
+    </div>
+  );
+}
+
+function SideItem({ icon, label, active, onClick }) {
+  return (
+    <div
+      onClick={onClick}
+      style={{
+        display: 'flex', alignItems: 'center', gap: 8,
+        padding: '5px 8px', borderRadius: 4, cursor: 'pointer',
+        background: active ? T.surface2 : 'transparent',
+        color: active ? T.text : T.textMute,
+        fontSize: 13, fontWeight: active ? 500 : 400,
+      }}
+    >
+      <I d={ICON[icon]} size={13} style={{ color: active ? T.text : T.textDim }} />
+      <span>{label}</span>
+    </div>
+  );
+}
+
+function SideProject({ name, count, active, onClick }) {
+  return (
+    <div
+      onClick={onClick}
+      style={{
+        display: 'flex', alignItems: 'center', gap: 8,
+        padding: '5px 8px', borderRadius: 4, cursor: 'pointer',
+        background: active ? T.surface2 : 'transparent',
+        color: active ? T.text : T.textMute,
+        fontSize: 13, fontWeight: active ? 500 : 400,
+      }}
+    >
+      <Dot color={active ? T.iris : T.textDim} size={6} />
+      <span style={{ flex: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{name}</span>
+      {count != null && <span style={{ fontSize: 11, color: T.textDim, fontFamily: MONO }}>{count}</span>}
+    </div>
+  );
+}
+
+export function Topbar({ project, active }) {
+  const labels = {
+    burnup: 'Burnup', gantt: 'Gantt', tasks: 'Tasks',
+    todos: 'Todos', subs: 'Sub-projects', merged: 'Merged',
+    timelog: 'Time log',
+  };
+  return (
+    <header style={{
+      height: 44, flexShrink: 0, background: T.surface,
+      borderBottom: `1px solid ${T.border}`,
+      display: 'flex', alignItems: 'center', padding: '0 16px', gap: 10,
+    }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 6, fontSize: 12, color: T.textMute }}>
+        <I d={ICON.folder} size={12} />
+        <span>{project}</span>
+        <I d={ICON.chevR} size={11} style={{ color: T.textDim }} />
+        <span style={{ color: T.text, fontWeight: 500 }}>{labels[active] || active}</span>
+      </div>
+    </header>
+  );
+}

--- a/src/design/primitives.jsx
+++ b/src/design/primitives.jsx
@@ -1,0 +1,160 @@
+// Shared primitives for the "next" UI. Ported from design bundle primitives.jsx.
+// Pure inline styles + design tokens; no Tailwind.
+// Icons are JSX fragments (not HTML strings) so we avoid dangerouslySetInnerHTML.
+
+import React from 'react';
+import { T, FONT, MONO } from './tokens.js';
+
+// Icon — any `d` value is a JSX fragment of SVG children (paths, lines, etc.)
+export function I({ d, size = 14, stroke = 1.5, style }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none"
+      stroke="currentColor" strokeWidth={stroke} strokeLinecap="round"
+      strokeLinejoin="round" style={{ flexShrink: 0, ...style }}>
+      {d}
+    </svg>
+  );
+}
+
+// Lucide-derived icon library (JSX fragments)
+export const ICON = {
+  plus: (<><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></>),
+  search: (<><circle cx="11" cy="11" r="7"/><line x1="21" y1="21" x2="16.5" y2="16.5"/></>),
+  chart: (<><line x1="4" y1="20" x2="4" y2="10"/><line x1="12" y1="20" x2="12" y2="4"/><line x1="20" y1="20" x2="20" y2="14"/></>),
+  trend: (<><polyline points="3 17 9 11 13 15 21 7"/><polyline points="14 7 21 7 21 14"/></>),
+  gantt: (<><rect x="3" y="6" width="10" height="3" rx="0.5"/><rect x="8" y="11" width="10" height="3" rx="0.5"/><rect x="5" y="16" width="8" height="3" rx="0.5"/></>),
+  kanban: (<><rect x="3" y="4" width="5" height="16" rx="0.5"/><rect x="10" y="4" width="5" height="10" rx="0.5"/><rect x="17" y="4" width="4" height="13" rx="0.5"/></>),
+  merge: (<><circle cx="6" cy="6" r="2"/><circle cx="6" cy="18" r="2"/><circle cx="18" cy="12" r="2"/><path d="M8 6c4 0 4 6 8 6"/><path d="M8 18c4 0 4-6 8-6"/></>),
+  folder: (<path d="M3 7a2 2 0 0 1 2-2h4l2 2h8a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/>),
+  people: (<><path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M22 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13A4 4 0 0 1 16 11"/></>),
+  user: (<><circle cx="12" cy="8" r="4"/><path d="M4 21a8 8 0 0 1 16 0"/></>),
+  settings: (<><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.7 1.7 0 0 0 .3 1.8l.1.1a2 2 0 1 1-2.8 2.8l-.1-.1a1.7 1.7 0 0 0-1.8-.3 1.7 1.7 0 0 0-1 1.5V21a2 2 0 1 1-4 0v-.1a1.7 1.7 0 0 0-1-1.5 1.7 1.7 0 0 0-1.8.3l-.1.1a2 2 0 1 1-2.8-2.8l.1-.1a1.7 1.7 0 0 0 .3-1.8 1.7 1.7 0 0 0-1.5-1H3a2 2 0 1 1 0-4h.1a1.7 1.7 0 0 0 1.5-1 1.7 1.7 0 0 0-.3-1.8l-.1-.1a2 2 0 1 1 2.8-2.8l.1.1a1.7 1.7 0 0 0 1.8.3h.1a1.7 1.7 0 0 0 1-1.5V3a2 2 0 1 1 4 0v.1a1.7 1.7 0 0 0 1 1.5 1.7 1.7 0 0 0 1.8-.3l.1-.1a2 2 0 1 1 2.8 2.8l-.1.1a1.7 1.7 0 0 0-.3 1.8v.1a1.7 1.7 0 0 0 1.5 1H21a2 2 0 1 1 0 4h-.1a1.7 1.7 0 0 0-1.5 1z"/></>),
+  calendar: (<><rect x="3" y="4" width="18" height="18" rx="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/></>),
+  clock: (<><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></>),
+  check: (<polyline points="20 6 9 17 4 12"/>),
+  x: (<><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></>),
+  chevR: (<polyline points="9 6 15 12 9 18"/>),
+  chevD: (<polyline points="6 9 12 15 18 9"/>),
+  more: (<><circle cx="12" cy="12" r="1"/><circle cx="19" cy="12" r="1"/><circle cx="5" cy="12" r="1"/></>),
+  filter: (<polygon points="22 3 2 3 10 12.46 10 19 14 21 14 12.46 22 3"/>),
+  maximize: (<><polyline points="15 3 21 3 21 9"/><polyline points="9 21 3 21 3 15"/><line x1="21" y1="3" x2="14" y2="10"/><line x1="3" y1="21" x2="10" y2="14"/></>),
+  alert: (<><path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></>),
+  cmd: (<path d="M18 3a3 3 0 0 0-3 3v12a3 3 0 0 0 3 3 3 3 0 0 0 3-3 3 3 0 0 0-3-3H6a3 3 0 0 0-3 3 3 3 0 0 0 3 3 3 3 0 0 0 3-3V6a3 3 0 0 0-3-3 3 3 0 0 0-3 3 3 3 0 0 0 3 3h12a3 3 0 0 0 3-3 3 3 0 0 0-3-3z"/>),
+  link: (<><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/></>),
+  msg: (<path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/>),
+  trash: (<><polyline points="3 6 5 6 21 6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/></>),
+  pencil: (<><path d="M12 20h9"/><path d="M16.5 3.5a2.12 2.12 0 0 1 3 3L7 19l-4 1 1-4z"/></>),
+  eye: (<><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></>),
+  upload: (<><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="17 8 12 3 7 8"/><line x1="12" y1="3" x2="12" y2="15"/></>),
+  download: (<><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></>),
+  grip: (<><circle cx="9" cy="6" r="1"/><circle cx="15" cy="6" r="1"/><circle cx="9" cy="12" r="1"/><circle cx="15" cy="12" r="1"/><circle cx="9" cy="18" r="1"/><circle cx="15" cy="18" r="1"/></>),
+  lock: (<><rect x="3" y="11" width="18" height="11" rx="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></>),
+  arrow: (<><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></>),
+  inbox: (<><polyline points="22 12 16 12 14 15 10 15 8 12 2 12"/><path d="M5.45 5.11L2 12v6a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2v-6l-3.45-6.89A2 2 0 0 0 16.76 4H7.24a2 2 0 0 0-1.79 1.11z"/></>),
+  keyboard: (<><rect x="2" y="4" width="20" height="16" rx="2"/><path d="M6 8h.01M10 8h.01M14 8h.01M18 8h.01M6 12h.01M10 12h.01M14 12h.01M18 12h.01M7 16h10"/></>),
+  bell: (<><path d="M18 8a6 6 0 0 0-12 0c0 7-3 9-3 9h18s-3-2-3-9"/><path d="M13.73 21a2 2 0 0 1-3.46 0"/></>),
+  send: (<><line x1="22" y1="2" x2="11" y2="13"/><polygon points="22 2 15 22 11 13 2 9 22 2"/></>),
+  flip: (<><polyline points="17 1 21 5 17 9"/><path d="M3 11V9a4 4 0 0 1 4-4h14"/><polyline points="7 23 3 19 7 15"/><path d="M21 13v2a4 4 0 0 1-4 4H3"/></>),
+};
+
+export function hashColor(s) {
+  const colors = ['#5B5BD6','#2DA44E','#D97706','#7C3AED','#DC2626','#0891B2','#DB2777'];
+  let h = 0; for (let i=0;i<s.length;i++) h = (h*31 + s.charCodeAt(i)) >>> 0;
+  return colors[h % colors.length];
+}
+
+export function Avatar({ name, size = 20 }) {
+  if (!name) return null;
+  return (
+    <div style={{
+      width: size, height: size, borderRadius: size,
+      background: hashColor(name), color:'#fff',
+      fontSize: size*0.45, fontWeight: 600,
+      display:'inline-flex', alignItems:'center', justifyContent:'center',
+      letterSpacing: 0, lineHeight: 1, flexShrink: 0,
+    }}>{name[0].toUpperCase()}</div>
+  );
+}
+
+export function Badge({ children, tone = 'neutral', size = 'md', style }) {
+  const tones = {
+    neutral: { bg: T.surface2, fg: T.textMute, bd: T.border },
+    iris:    { bg: T.irisSoft, fg: T.iris, bd: '#D7DAFF' },
+    green:   { bg: T.greenSoft, fg: T.green, bd: '#C6E5CC' },
+    warn:    { bg: T.warnSoft, fg: T.warn, bd: '#FDE68A' },
+    danger:  { bg: T.dangerSoft, fg: T.danger, bd: '#FECACA' },
+    violet:  { bg: T.violetSoft, fg: T.violet, bd: '#E0D4FB' },
+    solid:   { bg: T.text, fg: '#fff', bd: T.text },
+  };
+  const t = tones[tone] || tones.neutral;
+  const pad = size === 'sm' ? '1px 5px' : '2px 7px';
+  const fs = size === 'sm' ? 10 : 11;
+  return (
+    <span style={{
+      display:'inline-flex', alignItems:'center', gap:4,
+      padding: pad, fontSize: fs, fontWeight: 500,
+      color: t.fg, background: t.bg, border: `1px solid ${t.bd}`,
+      borderRadius: 4, lineHeight: 1.4, whiteSpace:'nowrap',
+      ...style,
+    }}>{children}</span>
+  );
+}
+
+export function Dot({ color = T.iris, size = 6 }) {
+  return <span style={{ width:size, height:size, borderRadius:size, background:color, display:'inline-block', flexShrink:0 }} />;
+}
+
+export function Btn({ children, variant = 'ghost', size = 'sm', icon, style, ...rest }) {
+  const h = size === 'sm' ? 24 : size === 'md' ? 28 : 32;
+  const variants = {
+    ghost:   { bg:'transparent', fg: T.textMute, bd:'transparent' },
+    subtle:  { bg: T.surface2,   fg: T.text,     bd: T.border },
+    primary: { bg: T.text,       fg:'#fff',      bd: T.text },
+    iris:    { bg: T.iris,       fg:'#fff',      bd: T.iris },
+    danger:  { bg:'transparent', fg: T.danger,   bd:'transparent' },
+  };
+  const v = variants[variant] || variants.ghost;
+  return (
+    <button {...rest} style={{
+      height: h, padding: `0 ${size==='sm'?8:10}px`,
+      background: v.bg, color: v.fg, border:`1px solid ${v.bd}`,
+      borderRadius: 4, fontSize: 12, fontWeight: 500,
+      display:'inline-flex', alignItems:'center', gap:6,
+      cursor:'pointer', fontFamily: FONT, whiteSpace:'nowrap',
+      ...style,
+    }}>
+      {icon && <I d={ICON[icon]} size={13} />}
+      {children}
+    </button>
+  );
+}
+
+export function Kbd({ children }) {
+  return <span style={{
+    padding:'1px 5px', fontSize:10, fontFamily: MONO,
+    color: T.textMute, background: T.surface, border: `1px solid ${T.border}`,
+    borderRadius: 3, minWidth: 16, textAlign:'center', lineHeight: 1.4,
+  }}>{children}</span>;
+}
+
+export function ActivityGlyph({ kind }) {
+  const map = {
+    log:      { icon: ICON.pencil,  color: T.textMute },
+    comment:  { icon: ICON.msg,     color: T.iris },
+    waiting:  { icon: ICON.clock,   color: T.warn },
+    decision: { icon: ICON.alert,   color: T.violet },
+    note:     { icon: ICON.pencil,  color: T.textMute },
+    done:     { icon: ICON.check,   color: T.green },
+  };
+  const m = map[kind] || map.log;
+  return (
+    <div style={{
+      width: 22, height: 22, borderRadius: 4,
+      background: T.surface2, color: m.color,
+      display:'inline-flex', alignItems:'center', justifyContent:'center',
+      border: `1px solid ${T.border}`, flexShrink: 0,
+    }}>
+      <I d={m.icon} size={11} />
+    </div>
+  );
+}

--- a/src/design/tokens.js
+++ b/src/design/tokens.js
@@ -1,0 +1,64 @@
+// Design tokens — Linear/Height-inspired, light, high-density.
+// Ported from new-burnup-design/project/screens/tokens.js.
+// Exported as ES modules instead of window globals.
+
+export const T = {
+  bg:       '#FAFAF9',
+  surface:  '#FFFFFF',
+  surface2: '#F5F5F4',
+  border:   '#E7E5E4',
+  borderStrong: '#D6D3D1',
+  divider:  '#F5F5F4',
+
+  text:     '#18181B',
+  textMute: '#52525B',
+  textDim:  '#A1A1AA',
+  textFaint:'#D4D4D8',
+
+  iris:     '#5B5BD6',
+  irisSoft: '#EEF0FE',
+  irisDim:  '#C9CDFF',
+  green:    '#2DA44E',
+  greenSoft:'#EAF6EC',
+
+  warn:     '#D97706',
+  warnSoft: '#FEF3C7',
+  danger:   '#DC2626',
+  dangerSoft:'#FEE2E2',
+  violet:   '#7C3AED',
+  violetSoft:'#F3EEFE',
+
+  today:    '#F59E0B',
+
+  r1: 4, r2: 6, r3: 8, r4: 10,
+};
+
+export const FONT = `"Geist", "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans TC", sans-serif`;
+export const MONO = `"Geist Mono", "IBM Plex Mono", ui-monospace, "SF Mono", Menlo, monospace`;
+
+export const DEFAULT_YEAR = 2026;
+
+export function weekCode(dateStr, fallbackYear) {
+  if (!dateStr) return '';
+  const y = fallbackYear ?? DEFAULT_YEAR;
+  const parts = String(dateStr).split('-').map(Number);
+  const [yy, mm, dd] = parts.length === 3 ? parts : [y, parts[0], parts[1]];
+  const d = new Date(Date.UTC(yy, mm - 1, dd));
+  const dayNum = (d.getUTCDay() + 6) % 7;
+  d.setUTCDate(d.getUTCDate() - dayNum + 3);
+  const firstThursday = new Date(Date.UTC(d.getUTCFullYear(), 0, 4));
+  const firstThursdayDay = (firstThursday.getUTCDay() + 6) % 7;
+  firstThursday.setUTCDate(firstThursday.getUTCDate() - firstThursdayDay + 3);
+  const week = 1 + Math.round((d - firstThursday) / (7 * 24 * 3600 * 1000));
+  const isoYear = d.getUTCFullYear();
+  return 'W' + (isoYear % 10) + String(week).padStart(2, '0');
+}
+
+export function weekCodeRange(startStr, endStr, fallbackYear) {
+  const a = weekCode(startStr, fallbackYear);
+  const b = weekCode(endStr, fallbackYear);
+  if (!a) return b;
+  if (!b || a === b) return a;
+  if (a[1] === b[1]) return a + '–' + b.slice(2);
+  return a + '→' + b;
+}

--- a/src/design/tokens.test.js
+++ b/src/design/tokens.test.js
@@ -1,0 +1,65 @@
+import { describe, test, expect } from 'vitest';
+import { weekCode, weekCodeRange } from './tokens.js';
+
+describe('weekCode', () => {
+  test('returns empty string for falsy input', () => {
+    expect(weekCode('')).toBe('');
+    expect(weekCode(null)).toBe('');
+    expect(weekCode(undefined)).toBe('');
+  });
+
+  test('ISO 8601 week for a Monday', () => {
+    // 2026-04-13 is the Monday of ISO week 16.
+    expect(weekCode('2026-04-13')).toBe('W616');
+  });
+
+  test('ISO 8601 week for a Sunday stays in same week', () => {
+    // 2026-04-19 (Sun) is still ISO week 16.
+    expect(weekCode('2026-04-19')).toBe('W616');
+  });
+
+  test('ISO year boundary early January', () => {
+    // 2026-01-01 (Thu) belongs to ISO year 2026 week 1.
+    expect(weekCode('2026-01-01')).toBe('W601');
+    // 2025-12-29 is ISO 2026 week 1 (week starts Mon of prior year).
+    expect(weekCode('2025-12-29')).toBe('W601');
+  });
+
+  test('ISO year boundary late December', () => {
+    // 2024-12-30 is ISO 2025 W01.
+    expect(weekCode('2024-12-30')).toBe('W501');
+  });
+
+  test('MM-DD form uses DEFAULT_YEAR', () => {
+    // No year: uses 2026.
+    expect(weekCode('04-13')).toBe('W616');
+  });
+
+  test('fallbackYear override wins over DEFAULT_YEAR', () => {
+    expect(weekCode('04-13', 2027)).toBe('W715');
+  });
+});
+
+describe('weekCodeRange', () => {
+  test('same week collapses to single code', () => {
+    expect(weekCodeRange('2026-04-13', '2026-04-17')).toBe('W616');
+  });
+
+  test('same year abbreviates to W616–17', () => {
+    expect(weekCodeRange('2026-04-13', '2026-04-20')).toBe('W616–17');
+  });
+
+  test('across ISO years uses full arrow', () => {
+    // 2024-12-30 is ISO 2025 W01 (year digit 5); 2026-01-05 is ISO 2026 W02.
+    // Different year digit → full arrow form.
+    expect(weekCodeRange('2024-12-30', '2026-01-05')).toBe('W501→W602');
+  });
+
+  test('missing start returns end code', () => {
+    expect(weekCodeRange('', '2026-04-13')).toBe('W616');
+  });
+
+  test('missing end returns start code', () => {
+    expect(weekCodeRange('2026-04-13', '')).toBe('W616');
+  });
+});

--- a/src/hooks/useAppData.js
+++ b/src/hooks/useAppData.js
@@ -1,0 +1,482 @@
+// Data layer for the "next" UI. Loads projects + active project data
+// independently so legacy App doesn't need to be refactored.
+// Mirrors only what the new pages consume.
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { fetchActivity, requestJson } from '../api.js';
+import { useAuth } from '../auth/AuthContext.jsx';
+
+const TODAY = () => new Date().toISOString().split('T')[0];
+
+function normalizeDate(value) {
+  if (!value) return '';
+  if (/^\d{4}-\d{2}-\d{2}$/.test(value)) return value;
+  const d = new Date(value);
+  if (Number.isNaN(d.getTime())) return value;
+  return d.toISOString().split('T')[0];
+}
+
+export function useAppData() {
+  const { user } = useAuth();
+  const [projects, setProjects] = useState([]);
+  const [todos, setTodos] = useState([]);
+  const [statuses, setStatuses] = useState([]);
+  const [subProjects, setSubProjects] = useState([]);
+  const [activeProjectId, setActiveProjectId] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    if (!user) { setLoading(false); return; }
+    let cancelled = false;
+    (async () => {
+      setLoading(true);
+      try {
+        const [projectData, statusData, todoData, subProjectData] = await Promise.all([
+          requestJson('/api/projects'),
+          requestJson('/api/statuses'),
+          requestJson('/api/todos'),
+          requestJson('/api/sub-projects'),
+        ]);
+        if (cancelled) return;
+        setProjects(projectData);
+        setStatuses(statusData);
+        setTodos(todoData);
+        setSubProjects(subProjectData);
+        if (projectData.length > 0 && !activeProjectId) {
+          setActiveProjectId(projectData[0].id);
+        }
+      } catch (err) {
+        if (!cancelled) setError(err);
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [user]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const activeProject = useMemo(
+    () => projects.find(p => p.id === activeProjectId) || null,
+    [projects, activeProjectId]
+  );
+
+  const allTasks = useMemo(
+    () => {
+      const normalized = (activeProject?.tasks || []).map(t => ({
+        ...t,
+        addedDate: normalizeDate(t.addedDate),
+        expectedStart: normalizeDate(t.expectedStart),
+        expectedEnd: normalizeDate(t.expectedEnd),
+        actualStart: normalizeDate(t.actualStart),
+        actualEnd: normalizeDate(t.actualEnd),
+      }));
+      return normalized.sort((a, b) => {
+        const aStart = a.expectedStart || '9999-12-31';
+        const bStart = b.expectedStart || '9999-12-31';
+        if (aStart < bStart) return -1;
+        if (aStart > bStart) return 1;
+        return 0;
+      });
+    },
+    [activeProject]
+  );
+
+  const endStatusId = useMemo(
+    () => statuses.find(s => s.isDefaultEnd)?.id,
+    [statuses]
+  );
+
+  const todoProgressByTask = useMemo(() => {
+    const map = {};
+    todos.forEach(t => {
+      if (!t.linkedTaskId) return;
+      if (!map[t.linkedTaskId]) map[t.linkedTaskId] = { total: 0, done: 0 };
+      map[t.linkedTaskId].total += 1;
+      if (t.status === endStatusId) map[t.linkedTaskId].done += 1;
+    });
+    return map;
+  }, [todos, endStatusId]);
+
+  // Unified activity feed for the active project.
+  const [activity, setActivity] = useState([]);
+  const [activityLoading, setActivityLoading] = useState(false);
+
+  const refreshActivity = useCallback(async () => {
+    if (!activeProjectId) { setActivity([]); return; }
+    setActivityLoading(true);
+    try {
+      const items = await fetchActivity(activeProjectId);
+      setActivity(items);
+    } catch (err) {
+      setError(err);
+    } finally {
+      setActivityLoading(false);
+    }
+  }, [activeProjectId]);
+
+  useEffect(() => { refreshActivity(); }, [refreshActivity]);
+
+  // Poll for new activity entries every 20 seconds. Skip when the tab
+  // is hidden; refresh immediately when it becomes visible again.
+  useEffect(() => {
+    if (!activeProjectId) return undefined;
+    const POLL_MS = 20_000;
+    const tick = () => { if (!document.hidden) refreshActivity(); };
+    const id = setInterval(tick, POLL_MS);
+    const onVis = () => { if (!document.hidden) refreshActivity(); };
+    document.addEventListener('visibilitychange', onVis);
+    return () => {
+      clearInterval(id);
+      document.removeEventListener('visibilitychange', onVis);
+    };
+  }, [activeProjectId, refreshActivity]);
+
+  const updateTodo = useCallback(async (todoId, patch) => {
+    setTodos(prev => prev.map(t => t.id === todoId ? { ...t, ...patch } : t));
+    try {
+      const updated = await requestJson(`/api/todos/${todoId}`, {
+        method: 'PATCH',
+        body: JSON.stringify(patch),
+      });
+      setTodos(prev => prev.map(t => t.id === todoId ? updated : t));
+      return updated;
+    } catch (err) {
+      setError(err);
+      return null;
+    }
+  }, []);
+
+  const createTodo = useCallback(async (payload) => {
+    try {
+      const created = await requestJson('/api/todos', {
+        method: 'POST',
+        body: JSON.stringify(payload),
+      });
+      setTodos(prev => [...prev, created]);
+      return created;
+    } catch (err) {
+      setError(err);
+      return null;
+    }
+  }, []);
+
+  const deleteTodo = useCallback(async (todoId) => {
+    try {
+      await requestJson(`/api/todos/${todoId}`, { method: 'DELETE' });
+      setTodos(prev => prev.filter(t => t.id !== todoId));
+      return true;
+    } catch (err) {
+      setError(err);
+      return false;
+    }
+  }, []);
+
+  const createComment = useCallback(async (todoId, content) => {
+    try {
+      const created = await requestJson(`/api/todos/${todoId}/comments`, {
+        method: 'POST',
+        body: JSON.stringify({ content }),
+      });
+      setTodos(prev => prev.map(t => t.id === todoId
+        ? { ...t, comments: [...(t.comments || []), created] }
+        : t));
+      return created;
+    } catch (err) {
+      setError(err);
+      return null;
+    }
+  }, []);
+
+  const updateComment = useCallback(async (commentId, content) => {
+    try {
+      const updated = await requestJson(`/api/todo-comments/${commentId}`, {
+        method: 'PATCH',
+        body: JSON.stringify({ content }),
+      });
+      setTodos(prev => prev.map(t => ({
+        ...t,
+        comments: (t.comments || []).map(c => c.id === commentId ? updated : c),
+      })));
+      return updated;
+    } catch (err) {
+      setError(err);
+      return null;
+    }
+  }, []);
+
+  const deleteComment = useCallback(async (commentId) => {
+    try {
+      await requestJson(`/api/todo-comments/${commentId}`, { method: 'DELETE' });
+      setTodos(prev => prev.map(t => ({
+        ...t,
+        comments: (t.comments || []).filter(c => c.id !== commentId),
+      })));
+      return true;
+    } catch (err) {
+      setError(err);
+      return false;
+    }
+  }, []);
+
+  const createStatus = useCallback(async ({ name, sortOrder }) => {
+    try {
+      const created = await requestJson('/api/statuses', {
+        method: 'POST',
+        body: JSON.stringify({ name, sort_order: sortOrder }),
+      });
+      // Re-fetch the authoritative order from the server to avoid state drift
+      // (identical pattern to updateStatus).
+      const refreshed = await requestJson('/api/statuses');
+      setStatuses(refreshed);
+      return created;
+    } catch (err) {
+      setError(err);
+      return null;
+    }
+  }, []);
+
+  const updateStatus = useCallback(async (id, patch) => {
+    const body = {};
+    if (patch.name !== undefined) body.name = patch.name;
+    if (patch.sortOrder !== undefined) body.sort_order = patch.sortOrder;
+    if (patch.isDefaultStart !== undefined) body.is_default_start = patch.isDefaultStart;
+    if (patch.isDefaultEnd !== undefined) body.is_default_end = patch.isDefaultEnd;
+    try {
+      await requestJson(`/api/statuses/${id}`, {
+        method: 'PATCH',
+        body: JSON.stringify(body),
+      });
+      const refreshed = await requestJson('/api/statuses');
+      setStatuses(refreshed);
+      return true;
+    } catch (err) {
+      setError(err);
+      return false;
+    }
+  }, []);
+
+  const deleteStatus = useCallback(async (id, migrateTo) => {
+    const url = migrateTo ? `/api/statuses/${id}?migrate_to=${migrateTo}` : `/api/statuses/${id}`;
+    try {
+      await requestJson(url, { method: 'DELETE' });
+      setStatuses(prev => prev.filter(s => s.id !== id));
+      if (migrateTo) {
+        setTodos(prev => prev.map(t => t.status === id ? { ...t, status: migrateTo } : t));
+      }
+      return true;
+    } catch (err) {
+      setError(err);
+      return false;
+    }
+  }, []);
+
+  const createSubProject = useCallback(async (projectId, payload) => {
+    try {
+      const created = await requestJson(`/api/projects/${projectId}/sub-projects`, {
+        method: 'POST',
+        body: JSON.stringify(payload),
+      });
+      setSubProjects(prev => [...prev, created]);
+      return created;
+    } catch (err) { setError(err); return null; }
+  }, []);
+
+  const updateSubProject = useCallback(async (spId, patch) => {
+    try {
+      const updated = await requestJson(`/api/sub-projects/${spId}`, {
+        method: 'PATCH',
+        body: JSON.stringify(patch),
+      });
+      setSubProjects(prev => prev.map(s => s.id === spId ? updated : s));
+      return updated;
+    } catch (err) { setError(err); return null; }
+  }, []);
+
+  const deleteSubProject = useCallback(async (spId) => {
+    try {
+      await requestJson(`/api/sub-projects/${spId}`, { method: 'DELETE' });
+      setSubProjects(prev => prev.filter(s => s.id !== spId));
+      return true;
+    } catch (err) { setError(err); return false; }
+  }, []);
+
+  const fetchSubProjectEvents = useCallback(async (spId) => {
+    try {
+      return await requestJson(`/api/sub-projects/${spId}/events`);
+    } catch (err) { setError(err); return []; }
+  }, []);
+
+  const createSubProjectEvent = useCallback(async (spId, payload) => {
+    try {
+      return await requestJson(`/api/sub-projects/${spId}/events`, {
+        method: 'POST',
+        body: JSON.stringify(payload),
+      });
+    } catch (err) { setError(err); return null; }
+  }, []);
+
+  const updateSubProjectEvent = useCallback(async (eventId, patch) => {
+    try {
+      return await requestJson(`/api/events/${eventId}`, {
+        method: 'PATCH',
+        body: JSON.stringify(patch),
+      });
+    } catch (err) { setError(err); return null; }
+  }, []);
+
+  const deleteSubProjectEvent = useCallback(async (eventId) => {
+    try {
+      await requestJson(`/api/events/${eventId}`, { method: 'DELETE' });
+      return true;
+    } catch (err) { setError(err); return false; }
+  }, []);
+
+  // -------- Time log (per-user) --------
+  const [timeEntries, setTimeEntries] = useState([]);
+
+  const refreshTimeEntries = useCallback(async () => {
+    if (!user) { setTimeEntries([]); return; }
+    try {
+      const list = await requestJson('/api/time-entries');
+      setTimeEntries(Array.isArray(list) ? list : []);
+    } catch (err) {
+      setError(err);
+    }
+  }, [user]);
+
+  useEffect(() => { refreshTimeEntries(); }, [refreshTimeEntries]);
+
+  const createTimeEntry = useCallback(async (payload) => {
+    try {
+      const created = await requestJson('/api/time-entries', {
+        method: 'POST',
+        body: JSON.stringify(payload),
+      });
+      setTimeEntries(prev => [created, ...prev]);
+      return created;
+    } catch (err) { setError(err); return null; }
+  }, []);
+
+  const updateTimeEntry = useCallback(async (id, patch) => {
+    try {
+      const updated = await requestJson(`/api/time-entries/${id}`, {
+        method: 'PATCH',
+        body: JSON.stringify(patch),
+      });
+      setTimeEntries(prev => prev.map(e => e.id === id ? updated : e));
+      return updated;
+    } catch (err) { setError(err); return null; }
+  }, []);
+
+  const deleteTimeEntry = useCallback(async (id) => {
+    try {
+      await requestJson(`/api/time-entries/${id}`, { method: 'DELETE' });
+      setTimeEntries(prev => prev.filter(e => e.id !== id));
+      return true;
+    } catch (err) { setError(err); return false; }
+  }, []);
+
+  const fetchTimeEntrySummary = useCallback(async (period, fromDate, toDate) => {
+    const params = new URLSearchParams({ period });
+    if (fromDate) params.set('from', fromDate);
+    if (toDate) params.set('to', toDate);
+    try {
+      return await requestJson(`/api/time-entries/summary?${params.toString()}`);
+    } catch (err) { setError(err); return null; }
+  }, []);
+
+  // Merged view state: which projects are included. Persisted in localStorage.
+  const [mergedProjectIds, setMergedProjectIds] = useState(() => {
+    try {
+      const raw = localStorage.getItem('mergedProjectIds');
+      return raw ? JSON.parse(raw) : [];
+    } catch { return []; }
+  });
+  useEffect(() => {
+    try { localStorage.setItem('mergedProjectIds', JSON.stringify(mergedProjectIds)); } catch { /* ignore */ }
+  }, [mergedProjectIds]);
+
+  const reorderStatuses = useCallback(async (ordered) => {
+    const body = ordered.map((s, i) => ({ id: s.id, sortOrder: i }));
+    const optimistic = ordered.map((s, i) => ({ ...s, sortOrder: i }));
+    setStatuses(optimistic);
+    try {
+      const refreshed = await requestJson('/api/statuses/reorder', {
+        method: 'POST',
+        body: JSON.stringify(body),
+      });
+      // Server returns the full sorted list; take it as source of truth.
+      if (Array.isArray(refreshed)) setStatuses(refreshed);
+      return true;
+    } catch (err) {
+      setError(err);
+      return false;
+    }
+  }, []);
+
+  const updateTask = useCallback(async (taskId, patch) => {
+    setProjects(prev => prev.map(p => p.id !== activeProjectId ? p : ({
+      ...p,
+      tasks: p.tasks.map(t => t.id === taskId ? { ...t, ...patch } : t),
+    })));
+    try {
+      const updated = await requestJson(`/api/tasks/${taskId}`, {
+        method: 'PATCH',
+        body: JSON.stringify(patch),
+      });
+      setProjects(prev => prev.map(p => p.id !== activeProjectId ? p : ({
+        ...p,
+        tasks: p.tasks.map(t => t.id === taskId ? updated : t),
+      })));
+      return updated;
+    } catch (err) {
+      setError(err);
+      return null;
+    }
+  }, [activeProjectId]);
+
+  return {
+    user,
+    loading,
+    error,
+    projects,
+    activeProject,
+    activeProjectId,
+    setActiveProjectId,
+    allTasks,
+    todos,
+    statuses,
+    subProjects,
+    todoProgressByTask,
+    today: TODAY(),
+    updateTask,
+    updateTodo,
+    createTodo,
+    deleteTodo,
+    createComment,
+    updateComment,
+    deleteComment,
+    createStatus,
+    updateStatus,
+    deleteStatus,
+    reorderStatuses,
+    createSubProject,
+    updateSubProject,
+    deleteSubProject,
+    fetchSubProjectEvents,
+    createSubProjectEvent,
+    updateSubProjectEvent,
+    deleteSubProjectEvent,
+    mergedProjectIds,
+    setMergedProjectIds,
+    timeEntries,
+    createTimeEntry,
+    updateTimeEntry,
+    deleteTimeEntry,
+    fetchTimeEntrySummary,
+    refreshTimeEntries,
+    activity,
+    activityLoading,
+    refreshActivity,
+  };
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,13 +1,13 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import App from './App.jsx';
+import AppRoot from './AppRoot.jsx';
 import { AuthProvider } from './auth/AuthContext';
 import './index.css';
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
     <AuthProvider>
-      <App />
+      <AppRoot />
     </AuthProvider>
   </React.StrictMode>,
 );

--- a/src/pages/BurnupPage.jsx
+++ b/src/pages/BurnupPage.jsx
@@ -1,0 +1,158 @@
+import React, { useMemo, useState } from 'react';
+import { T, FONT } from '../design/tokens.js';
+import { KpiStrip } from '../components/burnup/KpiStrip.jsx';
+import { BurnupChart } from '../components/burnup/BurnupChart.jsx';
+import { ActivityRail } from '../components/burnup/ActivityRail.jsx';
+import { TaskTable } from '../components/burnup/TaskTable.jsx';
+import {
+  annotateOverlap,
+  computeScope,
+  computeCompleted,
+  computePlannedToday,
+  computeVelocity,
+  computeAtRisk,
+  computeBurnupSeries,
+} from '../components/burnup/burnupMath.js';
+
+export function BurnupPage({ data }) {
+  const {
+    activeProject,
+    allTasks,
+    todoProgressByTask,
+    today,
+    updateTask,
+    activity,
+    activityLoading,
+    onSelectTask,
+  } = data;
+
+  const [chartStyle, setChartStyle] = useState('curve');
+  const [hideDone, setHideDone] = useState(false);
+
+  const tasksWithOverlap = useMemo(() => annotateOverlap(allTasks), [allTasks]);
+
+  const scope = useMemo(() => computeScope(tasksWithOverlap), [tasksWithOverlap]);
+  const completed = useMemo(() => computeCompleted(tasksWithOverlap, todoProgressByTask), [tasksWithOverlap, todoProgressByTask]);
+  const planned = useMemo(() => computePlannedToday(tasksWithOverlap, today), [tasksWithOverlap, today]);
+  const velocity = useMemo(() => computeVelocity(tasksWithOverlap, today), [tasksWithOverlap, today]);
+  const atRisk = useMemo(() => computeAtRisk(tasksWithOverlap), [tasksWithOverlap]);
+
+  const burnup = useMemo(
+    () => computeBurnupSeries(tasksWithOverlap, todoProgressByTask, today),
+    [tasksWithOverlap, todoProgressByTask, today]
+  );
+
+  const headlineHint = (() => {
+    if (scope === 0) return '尚無任務';
+    const pctDone = (completed / scope) * 100;
+    const pctPlanned = (planned / scope) * 100;
+    const diff = pctDone - pctPlanned;
+    if (Math.abs(diff) < 2) return 'on track';
+    return diff < 0
+      ? `behind by ~${Math.abs(Math.round(diff))}%`
+      : `ahead by ~${Math.round(diff)}%`;
+  })();
+  const headlineTone = headlineHint.startsWith('behind') ? T.warn : headlineHint.startsWith('ahead') ? T.green : T.textMute;
+
+  const handleProgressChange = async (taskId, value) => {
+    await updateTask(taskId, { progress: value });
+  };
+
+  const handleToggleShowLabel = async (taskId, next) => {
+    await updateTask(taskId, { showLabel: next });
+  };
+
+  return (
+    <div style={{ padding: 16, height: '100%', overflow: 'auto', background: T.bg }}>
+      {/* Header */}
+      <div style={{ display: 'flex', alignItems: 'baseline', justifyContent: 'space-between', marginBottom: 12 }}>
+        <div>
+          <h1 style={{ fontSize: 20, fontWeight: 600, letterSpacing: -0.4, margin: 0 }}>
+            {activeProject?.name || 'Burnup'}
+          </h1>
+          <div style={{ fontSize: 12, color: T.textMute, marginTop: 2 }}>
+            {allTasks.length} tasks ·{' '}
+            <span style={{ color: headlineTone, fontWeight: 500 }}>{headlineHint}</span>
+          </div>
+        </div>
+        <label style={{ display: 'inline-flex', alignItems: 'center', gap: 6, fontSize: 11, color: T.textMute }}>
+          Chart style
+          <select
+            value={chartStyle}
+            onChange={(e) => setChartStyle(e.target.value)}
+            style={{
+              height: 26, padding: '0 22px 0 8px', fontFamily: FONT, fontSize: 12,
+              color: T.text, background: T.surface, border: `1px solid ${T.border}`,
+              borderRadius: 4, cursor: 'pointer', appearance: 'none',
+              backgroundImage: `linear-gradient(45deg, transparent 50%, ${T.textDim} 50%), linear-gradient(135deg, ${T.textDim} 50%, transparent 50%)`,
+              backgroundPosition: `right 9px top 11px, right 5px top 11px`,
+              backgroundSize: '4px 4px, 4px 4px',
+              backgroundRepeat: 'no-repeat',
+            }}
+          >
+            <option value="curve">Curve</option>
+            <option value="step">Step</option>
+            <option value="area">Area</option>
+          </select>
+        </label>
+      </div>
+
+      <KpiStrip
+        scope={scope}
+        completed={completed}
+        planned={planned}
+        velocity={velocity}
+        atRisk={atRisk}
+      />
+
+      <div style={{
+        display: 'grid', gridTemplateColumns: '1fr 300px', gap: 12, marginBottom: 12,
+        height: 340, minHeight: 340,
+      }}>
+        <div style={{
+          background: T.surface, border: `1px solid ${T.border}`, borderRadius: 6,
+          padding: 14, display: 'flex', flexDirection: 'column', minHeight: 0,
+        }}>
+          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 8 }}>
+            <div style={{ display: 'flex', gap: 14, fontSize: 11, color: T.textMute }}>
+              <Legend color={T.iris} dashed label="Planned" />
+              <Legend color={T.green} label="Actual" />
+              <Legend color={T.today} vertical label={`Today · ${today.slice(5)}`} />
+            </div>
+            <div style={{ fontSize: 10, color: T.textDim }}>
+              {burnup.minDate && burnup.maxDate && `${burnup.minDate.slice(5)} → ${burnup.maxDate.slice(5)}`}
+            </div>
+          </div>
+          <BurnupChart data={burnup.data} annotations={burnup.annotations} style={chartStyle} today={today} />
+        </div>
+        <ActivityRail items={activity} loading={activityLoading} />
+      </div>
+
+      <TaskTable
+        tasks={tasksWithOverlap}
+        onUpdateProgress={handleProgressChange}
+        onToggleShowLabel={handleToggleShowLabel}
+        onSelectTask={onSelectTask}
+        hideDone={hideDone}
+        onToggleHideDone={() => setHideDone(v => !v)}
+      />
+    </div>
+  );
+}
+
+function Legend({ color, dashed, vertical, label }) {
+  return (
+    <span style={{ display: 'inline-flex', alignItems: 'center', gap: 5 }}>
+      <span style={{
+        width: vertical ? 2 : 12,
+        height: vertical ? 10 : 2,
+        background: color,
+        borderRadius: 1,
+        backgroundImage: dashed
+          ? `repeating-linear-gradient(90deg, ${color} 0 3px, transparent 3px 6px)`
+          : undefined,
+      }} />
+      {label}
+    </span>
+  );
+}

--- a/src/pages/GanttPage.jsx
+++ b/src/pages/GanttPage.jsx
@@ -1,0 +1,91 @@
+import React, { useMemo } from 'react';
+import { T, MONO } from '../design/tokens.js';
+import { GanttChart } from '../components/gantt/GanttChart.jsx';
+import { annotateOverlap } from '../components/burnup/burnupMath.js';
+
+export function GanttPage({ data }) {
+  const { activeProject, allTasks, today, user, updateTask } = data;
+  const readOnly = user?.role === 'viewer';
+
+  const tasksWithOverlap = useMemo(() => annotateOverlap(allTasks), [allTasks]);
+
+  const stats = useMemo(() => {
+    const byAssignee = new Map();
+    tasksWithOverlap.forEach(t => {
+      const k = t.people?.trim() || '__u__';
+      byAssignee.set(k, (byAssignee.get(k) || 0) + 1);
+    });
+    const overlapping = tasksWithOverlap.filter(t => (t._overlap || 1) >= 2);
+    return {
+      peopleCount: byAssignee.size,
+      overlapCount: overlapping.length,
+    };
+  }, [tasksWithOverlap]);
+
+  return (
+    <div style={{ padding: 16, height: '100%', overflow: 'auto', background: T.bg }}>
+      <div style={{ display: 'flex', alignItems: 'baseline', justifyContent: 'space-between', marginBottom: 12 }}>
+        <div>
+          <h1 style={{ fontSize: 20, fontWeight: 600, letterSpacing: -0.4, margin: 0 }}>
+            {activeProject?.name || 'Gantt'}
+          </h1>
+          <div style={{ fontSize: 12, color: T.textMute, marginTop: 2 }}>
+            {allTasks.length} tasks · {stats.peopleCount} people
+            {stats.overlapCount > 0 && (
+              <> · <span style={{ color: T.warn, fontWeight: 500, fontFamily: MONO }}>{stats.overlapCount}</span> overlap</>
+            )}
+          </div>
+        </div>
+      </div>
+
+      <GanttChart
+        tasks={tasksWithOverlap}
+        today={today}
+        height={520}
+        readOnly={readOnly}
+        onUpdateTask={updateTask}
+      />
+
+      <div style={{
+        display: 'flex', gap: 14, fontSize: 11, color: T.textMute,
+        marginTop: 10, flexWrap: 'wrap',
+      }}>
+        <LegendSwatch bg={T.irisSoft} border={T.irisDim}>Planned</LegendSwatch>
+        <LegendSwatch bg={T.green}>Actual · done</LegendSwatch>
+        <LegendSwatch
+          bg={`repeating-linear-gradient(135deg, ${T.green}, ${T.green} 3px, #68C07F 3px, #68C07F 6px)`}
+        >
+          Actual · in progress
+        </LegendSwatch>
+        <LegendSwatch
+          bg={`repeating-linear-gradient(135deg, ${T.warnSoft}, ${T.warnSoft} 4px, rgba(217,119,6,0.22) 4px, rgba(217,119,6,0.22) 8px)`}
+          border={T.warn}
+        >
+          Overlap · 2 concurrent
+        </LegendSwatch>
+        <LegendSwatch
+          bg={`repeating-linear-gradient(135deg, ${T.dangerSoft}, ${T.dangerSoft} 4px, rgba(220,38,38,0.18) 4px, rgba(220,38,38,0.18) 8px)`}
+          border={T.danger}
+        >
+          Overlap · 3+ concurrent
+        </LegendSwatch>
+        <span style={{ display: 'inline-flex', alignItems: 'center', gap: 5, color: T.textDim, fontFamily: MONO }}>
+          · 2L = row packed into 2 lanes
+        </span>
+      </div>
+    </div>
+  );
+}
+
+function LegendSwatch({ bg, border, children }) {
+  return (
+    <span style={{ display: 'inline-flex', alignItems: 'center', gap: 5 }}>
+      <span style={{
+        width: 16, height: 10, borderRadius: 2,
+        background: bg,
+        border: border ? `1px solid ${border}` : undefined,
+      }} />
+      {children}
+    </span>
+  );
+}

--- a/src/pages/LoginPage.jsx
+++ b/src/pages/LoginPage.jsx
@@ -1,0 +1,147 @@
+import React, { useState } from 'react';
+import { T, FONT } from '../design/tokens.js';
+import { I, ICON, Btn } from '../design/primitives.jsx';
+import { useAuth } from '../auth/AuthContext.jsx';
+
+// New UI login screen. Bootstrap mode auto-activates when the API
+// reports no users exist yet. Uses AuthContext.login / bootstrap.
+
+export function LoginPage() {
+  const { login, bootstrap, initialized } = useAuth();
+  const bootstrapMode = initialized === false;
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+
+  const onSubmit = async (e) => {
+    e.preventDefault();
+    if (!username.trim() || !password) return;
+    setSubmitting(true);
+    setError('');
+    try {
+      if (bootstrapMode) {
+        await bootstrap(username.trim(), password);
+      } else {
+        await login(username.trim(), password);
+      }
+    } catch (err) {
+      const msg = err?.message || String(err);
+      setError(bootstrapMode
+        ? msg.includes('8') ? 'Password must be at least 8 characters' : '建立管理員失敗：' + msg
+        : '登入失敗：請確認帳號密碼');
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div style={{
+      width: '100%', height: '100vh', background: T.bg,
+      display: 'flex', alignItems: 'center', justifyContent: 'center',
+      fontFamily: FONT,
+    }}>
+      <div style={{
+        width: 380, background: T.surface,
+        border: `1px solid ${T.border}`, borderRadius: 8, padding: 32,
+        boxShadow: '0 4px 16px rgba(0,0,0,0.05)',
+      }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 22 }}>
+          <div style={{
+            width: 32, height: 32, borderRadius: 6, background: T.text,
+            color: '#fff', fontSize: 16, fontWeight: 600,
+            display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
+          }}>B</div>
+          <div>
+            <div style={{ fontSize: 15, fontWeight: 600 }}>Burnup</div>
+            <div style={{ fontSize: 11, color: T.textDim }}>燃盡圖 · task tracker</div>
+          </div>
+        </div>
+
+        <div style={{ fontSize: 18, fontWeight: 600, letterSpacing: -0.3, marginBottom: 4 }}>
+          {bootstrapMode ? 'Create admin account' : 'Welcome back'}
+        </div>
+        <div style={{ fontSize: 12, color: T.textMute, marginBottom: 18 }}>
+          {bootstrapMode ? 'First-time setup · this user will be the admin.' : 'Sign in to continue.'}
+        </div>
+
+        <form onSubmit={onSubmit}>
+          <div style={{ marginBottom: 12 }}>
+            <label style={label}>Username</label>
+            <input
+              autoFocus
+              type="text"
+              value={username}
+              onChange={(e) => setUsername(e.target.value)}
+              placeholder="alice"
+              disabled={submitting}
+              style={input}
+            />
+          </div>
+          <div style={{ marginBottom: 8 }}>
+            <label style={label}>Password</label>
+            <input
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              disabled={submitting}
+              style={input}
+            />
+            {bootstrapMode && (
+              <div style={{ fontSize: 10, color: T.textDim, marginTop: 4 }}>
+                At least 8 characters
+              </div>
+            )}
+          </div>
+
+          {error && (
+            <div style={{
+              marginTop: 10, padding: '8px 10px',
+              background: T.dangerSoft, border: '1px solid #FECACA',
+              borderRadius: 4, fontSize: 11, color: T.danger,
+            }}>
+              {error}
+            </div>
+          )}
+
+          <Btn
+            variant="primary"
+            type="submit"
+            disabled={submitting || !username.trim() || !password}
+            style={{
+              width: '100%', justifyContent: 'center',
+              height: 34, fontSize: 13, marginTop: 14,
+            }}
+          >
+            {submitting ? '…' : bootstrapMode ? 'Create account & sign in' : 'Sign in'}
+          </Btn>
+        </form>
+
+        <div style={{
+          marginTop: 20, padding: '10px 12px',
+          background: T.surface2, borderRadius: 5,
+          fontSize: 11, color: T.textMute,
+          display: 'flex', gap: 8, alignItems: 'flex-start',
+        }}>
+          <I d={ICON.lock} size={12} style={{ color: T.textDim, marginTop: 1 }} />
+          <div>
+            JWT · 30 min access · 7 d refresh
+            <div style={{ color: T.textDim, marginTop: 2 }}>
+              Token rotation · reuse detection auto-logout
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+const label = {
+  fontSize: 11, color: T.textMute, fontWeight: 500,
+  display: 'block', marginBottom: 4,
+};
+const input = {
+  width: '100%', padding: '7px 10px',
+  border: `1px solid ${T.border}`, borderRadius: 5,
+  fontSize: 13, fontFamily: FONT, outline: 'none',
+  boxSizing: 'border-box', color: T.text, background: T.surface,
+};

--- a/src/pages/MergedPage.jsx
+++ b/src/pages/MergedPage.jsx
@@ -1,0 +1,280 @@
+import React, { useMemo, useState } from 'react';
+import { T, MONO, FONT } from '../design/tokens.js';
+import { Btn, Badge, Dot, I, ICON } from '../design/primitives.jsx';
+import { BurnupChart } from '../components/burnup/BurnupChart.jsx';
+import { KpiStrip } from '../components/burnup/KpiStrip.jsx';
+import {
+  annotateOverlap,
+  computeScope,
+  computeCompleted,
+  computePlannedToday,
+  computeVelocity,
+  computeAtRisk,
+  computeBurnupSeries,
+} from '../components/burnup/burnupMath.js';
+
+function normalizeDate(v) {
+  if (!v) return '';
+  if (/^\d{4}-\d{2}-\d{2}$/.test(v)) return v;
+  const d = new Date(v);
+  return Number.isNaN(d.getTime()) ? v : d.toISOString().split('T')[0];
+}
+
+function normalizeTask(t) {
+  return {
+    ...t,
+    addedDate: normalizeDate(t.addedDate),
+    expectedStart: normalizeDate(t.expectedStart),
+    expectedEnd: normalizeDate(t.expectedEnd),
+    actualStart: normalizeDate(t.actualStart),
+    actualEnd: normalizeDate(t.actualEnd),
+  };
+}
+
+const SERIES_COLORS = [T.iris, T.green, T.violet, T.warn, T.danger, T.today];
+
+export function MergedPage({ data }) {
+  const { projects, mergedProjectIds, setMergedProjectIds, today, todoProgressByTask } = data;
+
+  const [showPicker, setShowPicker] = useState(mergedProjectIds.length === 0);
+
+  const selectedProjects = useMemo(
+    () => projects.filter(p => mergedProjectIds.includes(p.id)),
+    [projects, mergedProjectIds]
+  );
+
+  const tasksByProject = useMemo(() => {
+    const map = new Map();
+    selectedProjects.forEach(p => {
+      map.set(p.id, (p.tasks || []).map(normalizeTask));
+    });
+    return map;
+  }, [selectedProjects]);
+
+  const allTasks = useMemo(() => {
+    const out = [];
+    tasksByProject.forEach(list => list.forEach(t => out.push(t)));
+    return out;
+  }, [tasksByProject]);
+
+  const tasksWithOverlap = useMemo(() => annotateOverlap(allTasks), [allTasks]);
+  const burnup = useMemo(
+    () => computeBurnupSeries(tasksWithOverlap, todoProgressByTask, today),
+    [tasksWithOverlap, todoProgressByTask, today]
+  );
+
+  const scope = useMemo(() => computeScope(tasksWithOverlap), [tasksWithOverlap]);
+  const completed = useMemo(() => computeCompleted(tasksWithOverlap, todoProgressByTask), [tasksWithOverlap, todoProgressByTask]);
+  const planned = useMemo(() => computePlannedToday(tasksWithOverlap, today), [tasksWithOverlap, today]);
+  const velocity = useMemo(() => computeVelocity(tasksWithOverlap, today), [tasksWithOverlap, today]);
+  const atRisk = useMemo(() => computeAtRisk(tasksWithOverlap), [tasksWithOverlap]);
+
+  const contributions = useMemo(() => {
+    const total = scope || 1;
+    return selectedProjects.map((p, i) => {
+      const pts = (tasksByProject.get(p.id) || [])
+        .reduce((s, t) => s + (parseInt(t.points, 10) || 0), 0);
+      return {
+        id: p.id,
+        name: p.name,
+        points: pts,
+        pct: (pts / total) * 100,
+        color: SERIES_COLORS[i % SERIES_COLORS.length],
+      };
+    });
+  }, [selectedProjects, tasksByProject, scope]);
+
+  const toggleProject = (pid) => {
+    if (mergedProjectIds.includes(pid)) {
+      setMergedProjectIds(mergedProjectIds.filter(id => id !== pid));
+    } else {
+      setMergedProjectIds([...mergedProjectIds, pid]);
+    }
+  };
+
+  return (
+    <div style={{ padding: 16, height: '100%', overflow: 'auto', background: T.bg }}>
+      <div style={{ display: 'flex', alignItems: 'baseline', justifyContent: 'space-between', marginBottom: 12 }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          <h1 style={{ fontSize: 20, fontWeight: 600, letterSpacing: -0.4, margin: 0 }}>Merged view</h1>
+          <Badge tone="violet">
+            <I d={ICON.merge} size={10} />read-only
+          </Badge>
+        </div>
+        <Btn variant="subtle" icon="settings" onClick={() => setShowPicker(true)}>
+          Reconfigure merge
+        </Btn>
+      </div>
+
+      {/* Scope banner */}
+      <div style={{
+        padding: '8px 12px', background: T.violetSoft, border: '1px solid #E0D4FB',
+        borderRadius: 6, marginBottom: 12, display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap',
+      }}>
+        <span style={{ fontSize: 11, color: T.violet, fontWeight: 600, textTransform: 'uppercase', letterSpacing: 0.5 }}>
+          Scope
+        </span>
+        {selectedProjects.length === 0 ? (
+          <span style={{ fontSize: 12, color: T.textDim }}>No projects selected</span>
+        ) : (
+          selectedProjects.map(p => (
+            <Badge key={p.id} tone="violet" size="md">
+              <Dot color={T.violet} />{p.name} · {(p.tasks || []).length}
+            </Badge>
+          ))
+        )}
+        <span style={{ marginLeft: 'auto', fontSize: 11, color: T.textMute, fontFamily: MONO }}>
+          {allTasks.length} tasks · {scope} pts
+        </span>
+      </div>
+
+      {selectedProjects.length === 0 ? (
+        <div style={{
+          padding: 40, textAlign: 'center',
+          background: T.surface, border: `1px dashed ${T.border}`, borderRadius: 6,
+        }}>
+          <div style={{ fontSize: 14, fontWeight: 600, marginBottom: 4 }}>Pick projects to merge</div>
+          <div style={{ fontSize: 12, color: T.textMute, marginBottom: 12 }}>
+            Combined burnup of the selected projects will appear here.
+          </div>
+          <Btn variant="primary" icon="plus" onClick={() => setShowPicker(true)}>
+            Select projects
+          </Btn>
+        </div>
+      ) : (
+        <>
+          <KpiStrip
+            scope={scope}
+            completed={completed}
+            planned={planned}
+            velocity={velocity}
+            atRisk={atRisk}
+          />
+
+          <div style={{ display: 'grid', gridTemplateColumns: '1fr 300px', gap: 12, marginBottom: 12 }}>
+            <div style={{
+              background: T.surface, border: `1px solid ${T.border}`, borderRadius: 6, padding: 14,
+            }}>
+              <div style={{ fontSize: 12, fontWeight: 600, marginBottom: 6 }}>Aggregated burnup</div>
+              <BurnupChart
+                data={burnup.data}
+                annotations={burnup.annotations}
+                today={today}
+                height={260}
+              />
+            </div>
+
+            <div style={{
+              background: T.surface, border: `1px solid ${T.border}`, borderRadius: 6, padding: 12,
+            }}>
+              <div style={{ fontSize: 12, fontWeight: 600, marginBottom: 8 }}>Per-project contribution</div>
+              {contributions.map(c => (
+                <div key={c.id} style={{ marginBottom: 10 }}>
+                  <div style={{
+                    display: 'flex', justifyContent: 'space-between',
+                    fontSize: 11, marginBottom: 3,
+                  }}>
+                    <span style={{ display: 'inline-flex', alignItems: 'center', gap: 4 }}>
+                      <Dot color={c.color} />{c.name}
+                    </span>
+                    <span style={{ fontFamily: MONO, color: T.textMute }}>
+                      {c.points}pt · {c.pct.toFixed(0)}%
+                    </span>
+                  </div>
+                  <div style={{
+                    height: 5, background: T.surface2, borderRadius: 3, overflow: 'hidden',
+                  }}>
+                    <div style={{ width: `${c.pct}%`, height: '100%', background: c.color }} />
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        </>
+      )}
+
+      {showPicker && (
+        <MergePickerModal
+          projects={projects}
+          selected={new Set(mergedProjectIds)}
+          onToggle={toggleProject}
+          onClose={() => setShowPicker(false)}
+          onConfirm={() => setShowPicker(false)}
+        />
+      )}
+    </div>
+  );
+}
+
+function MergePickerModal({ projects, selected, onToggle, onClose, onConfirm }) {
+  const totalTasks = projects
+    .filter(p => selected.has(p.id))
+    .reduce((n, p) => n + (p.tasks || []).length, 0);
+  return (
+    <div style={overlay} onClick={onClose}>
+      <div style={modal} onClick={(e) => e.stopPropagation()}>
+        <div style={{ padding: '14px 16px', borderBottom: `1px solid ${T.divider}` }}>
+          <div style={{ fontSize: 14, fontWeight: 600 }}>Select projects to merge</div>
+          <div style={{ fontSize: 11, color: T.textMute, marginTop: 2 }}>
+            Choice is remembered locally
+          </div>
+        </div>
+        <div style={{ padding: 10, maxHeight: 360, overflow: 'auto' }}>
+          {projects.length === 0 ? (
+            <div style={{ padding: 12, textAlign: 'center', fontSize: 12, color: T.textDim }}>
+              No projects
+            </div>
+          ) : projects.map(p => {
+            const isSel = selected.has(p.id);
+            return (
+              <label key={p.id} style={{
+                display: 'flex', alignItems: 'center', gap: 10, padding: '8px 10px',
+                borderRadius: 5, cursor: 'pointer',
+                background: isSel ? T.violetSoft : 'transparent',
+                border: `1px solid ${isSel ? '#E0D4FB' : 'transparent'}`,
+                marginBottom: 4,
+              }}>
+                <input
+                  type="checkbox"
+                  checked={isSel}
+                  onChange={() => onToggle(p.id)}
+                  style={{ accentColor: T.violet }}
+                />
+                <Dot color={isSel ? T.violet : T.textDim} />
+                <div style={{ flex: 1, fontSize: 13, fontWeight: isSel ? 500 : 400 }}>{p.name}</div>
+                <span style={{ fontSize: 11, color: T.textDim, fontFamily: MONO }}>
+                  {(p.tasks || []).length} tasks
+                </span>
+              </label>
+            );
+          })}
+        </div>
+        <div style={{
+          padding: '10px 16px', borderTop: `1px solid ${T.divider}`,
+          display: 'flex', justifyContent: 'space-between', alignItems: 'center',
+        }}>
+          <span style={{ fontSize: 11, color: T.textMute, fontFamily: MONO }}>
+            {selected.size} selected · {totalTasks} tasks
+          </span>
+          <div style={{ display: 'flex', gap: 6 }}>
+            <Btn variant="subtle" onClick={onClose}>Cancel</Btn>
+            <Btn variant="primary" onClick={onConfirm}>Confirm</Btn>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+const overlay = {
+  position: 'fixed', inset: 0, background: 'rgba(15,15,15,0.35)',
+  display: 'flex', alignItems: 'center', justifyContent: 'center',
+  zIndex: 200, padding: 20,
+};
+const modal = {
+  background: T.surface, color: T.text, fontFamily: FONT,
+  border: `1px solid ${T.border}`, borderRadius: 8,
+  width: 440, maxWidth: '100%', maxHeight: '90vh',
+  display: 'flex', flexDirection: 'column',
+  boxShadow: '0 12px 36px rgba(0,0,0,0.14)',
+};

--- a/src/pages/SubProjectsPage.jsx
+++ b/src/pages/SubProjectsPage.jsx
@@ -1,0 +1,225 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { T, MONO, FONT } from '../design/tokens.js';
+import { Btn, Badge, ActivityGlyph } from '../design/primitives.jsx';
+import { SubProjectCard } from '../components/subs/SubProjectCard.jsx';
+import { ActivityComposer } from '../components/subs/ActivityComposer.jsx';
+import { SubProjectFormModal } from '../components/subs/SubProjectFormModal.jsx';
+import { formatRelative } from '../design/formatTime.js';
+
+function EventItem({ event, onResolve, onDelete }) {
+  const { type, title, body, waitingOn, startedAt, resolvedAt } = event;
+  const tone = type === 'waiting' ? 'warn' : type === 'decision' ? 'violet' : 'neutral';
+  const isResolvedWaiting = type === 'waiting' && resolvedAt;
+  return (
+    <div style={{ display: 'flex', gap: 8, padding: '8px 0', borderBottom: `1px solid ${T.divider}` }}>
+      <ActivityGlyph kind={type === 'note' ? 'log' : type} />
+      <div style={{ flex: 1, minWidth: 0, fontSize: 12 }}>
+        <div style={{ display: 'flex', alignItems: 'baseline', gap: 6, marginBottom: 2, flexWrap: 'wrap' }}>
+          <Badge tone={tone} size="sm">{type}</Badge>
+          <span style={{ fontWeight: 500 }}>{title}</span>
+          {isResolvedWaiting && <Badge tone="green" size="sm">resolved</Badge>}
+          <span style={{ fontSize: 10, color: T.textDim, marginLeft: 'auto' }}>{formatRelative(startedAt)}</span>
+        </div>
+        {body && (
+          <div style={{ color: T.textMute, lineHeight: 1.5, wordBreak: 'break-word' }}>
+            {body}
+          </div>
+        )}
+        {waitingOn && (
+          <div style={{ fontSize: 11, color: T.warn, marginTop: 3 }}>↪ {waitingOn}</div>
+        )}
+        <div style={{ display: 'flex', gap: 6, marginTop: 4 }}>
+          {type === 'waiting' && !resolvedAt && (
+            <button onClick={() => onResolve?.(event.id)} style={miniBtn(T.green)}>Resolve</button>
+          )}
+          <button onClick={() => onDelete?.(event.id)} style={miniBtn(T.danger)}>Delete</button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+const miniBtn = (color) => ({
+  fontSize: 10, padding: '2px 6px', cursor: 'pointer',
+  background: 'transparent', border: `1px solid ${T.border}`,
+  borderRadius: 3, color, fontFamily: FONT,
+});
+
+export function SubProjectsPage({ data }) {
+  const {
+    subProjects, activeProjectId, allTasks,
+    createSubProject, updateSubProject, deleteSubProject,
+    fetchSubProjectEvents, createSubProjectEvent, updateSubProjectEvent, deleteSubProjectEvent,
+  } = data;
+
+  const projectSubs = useMemo(
+    () => subProjects.filter(s => s.burnupProjectId === activeProjectId),
+    [subProjects, activeProjectId]
+  );
+
+  const [selectedId, setSelectedId] = useState(null);
+  const [editing, setEditing] = useState(null); // null | {} for new | sub-project obj for edit
+  const [events, setEvents] = useState([]);
+  const [eventFilter, setEventFilter] = useState('all');
+  const [eventsLoading, setEventsLoading] = useState(false);
+
+  const selected = useMemo(
+    () => projectSubs.find(s => s.id === selectedId) || projectSubs[0] || null,
+    [projectSubs, selectedId]
+  );
+
+  const refreshEvents = async (spId) => {
+    if (!spId) { setEvents([]); return; }
+    setEventsLoading(true);
+    const list = await fetchSubProjectEvents(spId);
+    setEvents(Array.isArray(list) ? list : []);
+    setEventsLoading(false);
+  };
+
+  useEffect(() => { refreshEvents(selected?.id); }, [selected?.id]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const waitingCount = projectSubs.reduce((n, s) => n + (s.activeWaitingCount || 0), 0);
+
+  const handleSave = async (payload) => {
+    if (payload.id) {
+      const { id, ...patch } = payload;
+      await updateSubProject(id, patch);
+    } else {
+      await createSubProject(activeProjectId, payload);
+    }
+    setEditing(null);
+  };
+
+  const handleDelete = async (sp) => {
+    if (!confirm(`Delete sub-project "${sp.name}"?`)) return;
+    await deleteSubProject(sp.id);
+    if (selectedId === sp.id) setSelectedId(null);
+  };
+
+  const handlePost = async (payload) => {
+    if (!selected) return false;
+    const created = await createSubProjectEvent(selected.id, payload);
+    if (created) {
+      await refreshEvents(selected.id);
+      // refresh waiting count in card
+      await updateSubProject(selected.id, {}); // noop patch just to refresh? skip.
+      return true;
+    }
+    return false;
+  };
+
+  const handleResolve = async (eventId) => {
+    await updateSubProjectEvent(eventId, { resolvedAt: new Date().toISOString() });
+    await refreshEvents(selected?.id);
+  };
+
+  const handleDeleteEvent = async (eventId) => {
+    await deleteSubProjectEvent(eventId);
+    await refreshEvents(selected?.id);
+  };
+
+  const filteredEvents = useMemo(() => {
+    if (eventFilter === 'all') return events;
+    return events.filter(e => e.type === eventFilter);
+  }, [events, eventFilter]);
+
+  return (
+    <div style={{ padding: 16, height: '100%', overflow: 'auto', background: T.bg }}>
+      <div style={{ display: 'flex', alignItems: 'baseline', justifyContent: 'space-between', marginBottom: 12 }}>
+        <div>
+          <h1 style={{ fontSize: 20, fontWeight: 600, letterSpacing: -0.4, margin: 0 }}>Sub-projects</h1>
+          <div style={{ fontSize: 12, color: T.textMute, marginTop: 2 }}>
+            {projectSubs.length} tracked
+            {waitingCount > 0 && <> · <span style={{ color: T.warn, fontWeight: 500 }}>{waitingCount} waiting open</span></>}
+          </div>
+        </div>
+        <Btn variant="primary" icon="plus" onClick={() => setEditing({})}>New sub-project</Btn>
+      </div>
+
+      {projectSubs.length === 0 ? (
+        <div style={{
+          padding: 40, textAlign: 'center',
+          background: T.surface, border: `1px dashed ${T.border}`, borderRadius: 6,
+        }}>
+          <div style={{ fontSize: 14, fontWeight: 600, marginBottom: 4 }}>No sub-projects yet</div>
+          <div style={{ fontSize: 12, color: T.textMute, marginBottom: 12 }}>
+            Group related tasks and track waiting / decisions separately from the main burnup.
+          </div>
+          <Btn variant="primary" icon="plus" onClick={() => setEditing({})}>Create the first one</Btn>
+        </div>
+      ) : (
+        <>
+          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(320px, 1fr))', gap: 10, marginBottom: 14 }}>
+            {projectSubs.map(sp => (
+              <SubProjectCard
+                key={sp.id}
+                sp={sp}
+                selected={selected?.id === sp.id}
+                onClick={() => setSelectedId(sp.id)}
+                onEdit={(x) => setEditing(x)}
+                onDelete={(x) => handleDelete(x)}
+              />
+            ))}
+          </div>
+
+          {selected && (
+            <div style={{ background: T.surface, border: `1px solid ${T.border}`, borderRadius: 6 }}>
+              <div style={{
+                padding: '10px 14px', borderBottom: `1px solid ${T.divider}`,
+                display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+              }}>
+                <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                  <div style={{ fontSize: 13, fontWeight: 600 }}>
+                    Activity · {selected.name}
+                  </div>
+                  <span style={{ fontSize: 10, color: T.textDim, fontFamily: MONO }}>
+                    {filteredEvents.length} event{filteredEvents.length === 1 ? '' : 's'}
+                  </span>
+                </div>
+                <div style={{ display: 'flex', gap: 4 }}>
+                  {['all', 'waiting', 'decision', 'note'].map(f => (
+                    <Btn
+                      key={f}
+                      variant={eventFilter === f ? 'subtle' : 'ghost'}
+                      onClick={() => setEventFilter(f)}
+                    >
+                      {f === 'all' ? 'All' : f[0].toUpperCase() + f.slice(1)}
+                    </Btn>
+                  ))}
+                </div>
+              </div>
+              <div style={{ padding: '4px 14px 12px' }}>
+                {eventsLoading ? (
+                  <div style={{ padding: 12, textAlign: 'center', fontSize: 11, color: T.textDim }}>Loading…</div>
+                ) : filteredEvents.length === 0 ? (
+                  <div style={{ padding: 12, textAlign: 'center', fontSize: 11, color: T.textDim }}>
+                    No events yet
+                  </div>
+                ) : (
+                  filteredEvents.map(e => (
+                    <EventItem
+                      key={e.id}
+                      event={e}
+                      onResolve={handleResolve}
+                      onDelete={handleDeleteEvent}
+                    />
+                  ))
+                )}
+                <ActivityComposer onPost={handlePost} disabled={!selected} />
+              </div>
+            </div>
+          )}
+        </>
+      )}
+
+      {editing && (
+        <SubProjectFormModal
+          subProject={editing?.id ? editing : null}
+          allTasks={allTasks}
+          onSave={handleSave}
+          onClose={() => setEditing(null)}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/pages/SubProjectsPage.jsx
+++ b/src/pages/SubProjectsPage.jsx
@@ -76,7 +76,11 @@ export function SubProjectsPage({ data }) {
     setEventsLoading(false);
   };
 
-  useEffect(() => { refreshEvents(selected?.id); }, [selected?.id]); // eslint-disable-line react-hooks/exhaustive-deps
+  // Load the selected sub-project's events whenever the selection changes.
+  // This is a legitimate data-fetching effect (async state sync with an
+  // external system), hence the disable.
+  // eslint-disable-next-line react-hooks/set-state-in-effect, react-hooks/exhaustive-deps
+  useEffect(() => { refreshEvents(selected?.id); }, [selected?.id]);
 
   const waitingCount = projectSubs.reduce((n, s) => n + (s.activeWaitingCount || 0), 0);
 

--- a/src/pages/TimeLogPage.jsx
+++ b/src/pages/TimeLogPage.jsx
@@ -285,10 +285,13 @@ function EntryRow({ entry, color, editing, onStartEdit, onCancelEdit, onUpdate, 
   const [draft, setDraft] = useState({
     item: entry.item, hours: String(entry.hours), date: entry.date, note: entry.note || '',
   });
-
-  useEffect(() => {
+  // Re-sync the draft whenever the backing entry changes (e.g. after a
+  // successful update). Render-time prop sync avoids setState-in-effect.
+  const [lastEntry, setLastEntry] = useState(entry);
+  if (entry !== lastEntry) {
+    setLastEntry(entry);
     setDraft({ item: entry.item, hours: String(entry.hours), date: entry.date, note: entry.note || '' });
-  }, [entry]);
+  }
 
   const save = async () => {
     const patch = {

--- a/src/pages/TimeLogPage.jsx
+++ b/src/pages/TimeLogPage.jsx
@@ -1,0 +1,465 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { T, FONT, MONO } from '../design/tokens.js';
+import { Btn, Badge, I, ICON } from '../design/primitives.jsx';
+
+// Personal time log page: quick-entry form + grouped entry list +
+// summary by period (day / week / month) with percent breakdown.
+
+function todayIso() {
+  return new Date().toISOString().split('T')[0];
+}
+
+function weekdayIso(date) {
+  const d = new Date(date);
+  return d.toLocaleDateString(undefined, { weekday: 'short' });
+}
+
+const SERIES_COLORS = [T.iris, T.green, T.violet, T.warn, T.danger, '#0891B2', '#DB2777', '#52525B'];
+
+function pickColor(i) {
+  return SERIES_COLORS[i % SERIES_COLORS.length];
+}
+
+export function TimeLogPage({ data }) {
+  const {
+    timeEntries,
+    createTimeEntry, updateTimeEntry, deleteTimeEntry,
+    refreshTimeEntries, fetchTimeEntrySummary,
+  } = data;
+
+  const [period, setPeriod] = useState('day');
+  const [summary, setSummary] = useState(null);
+  const [editingId, setEditingId] = useState(null);
+
+  const knownItems = useMemo(() => {
+    const s = new Set();
+    timeEntries.forEach(e => { if (e.item) s.add(e.item); });
+    return Array.from(s).sort();
+  }, [timeEntries]);
+
+  // Build a colour map keyed by item, stable across renders.
+  const itemColor = useMemo(() => {
+    const entries = [...new Set(timeEntries.map(e => e.item))].sort();
+    const map = new Map();
+    entries.forEach((name, i) => map.set(name, pickColor(i)));
+    return map;
+  }, [timeEntries]);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetchTimeEntrySummary(period).then(r => { if (!cancelled && r) setSummary(r); });
+    return () => { cancelled = true; };
+  }, [period, timeEntries.length, fetchTimeEntrySummary]);
+
+  const groupedByDate = useMemo(() => {
+    const map = new Map();
+    timeEntries.forEach(e => {
+      if (!map.has(e.date)) map.set(e.date, []);
+      map.get(e.date).push(e);
+    });
+    const keys = Array.from(map.keys()).sort().reverse();
+    return keys.map(date => ({
+      date,
+      entries: map.get(date).sort((a, b) => (b.createdAt || '').localeCompare(a.createdAt || '')),
+      total: map.get(date).reduce((s, e) => s + (e.hours || 0), 0),
+    }));
+  }, [timeEntries]);
+
+  return (
+    <div style={{
+      padding: 16, height: '100%', overflow: 'auto', background: T.bg, fontFamily: FONT,
+    }}>
+      <header style={{ display: 'flex', alignItems: 'baseline', justifyContent: 'space-between', marginBottom: 12 }}>
+        <div>
+          <h1 style={{ fontSize: 20, fontWeight: 600, letterSpacing: -0.4, margin: 0 }}>Time log</h1>
+          <div style={{ fontSize: 12, color: T.textMute, marginTop: 2 }}>
+            {timeEntries.length} entries · {summary?.overall?.total ?? 0} hours total
+          </div>
+        </div>
+        <Btn variant="ghost" onClick={refreshTimeEntries}>Refresh</Btn>
+      </header>
+
+      <QuickEntryForm
+        knownItems={knownItems}
+        onSubmit={async (payload) => { await createTimeEntry(payload); }}
+      />
+
+      <div style={{ display: 'grid', gridTemplateColumns: '1fr 320px', gap: 12, alignItems: 'flex-start', marginTop: 12 }}>
+        {/* Left: entries grouped by date */}
+        <section>
+          {groupedByDate.length === 0 ? (
+            <EmptyState />
+          ) : groupedByDate.map(group => (
+            <DateGroup
+              key={group.date}
+              group={group}
+              itemColor={itemColor}
+              editingId={editingId}
+              setEditingId={setEditingId}
+              onUpdate={updateTimeEntry}
+              onDelete={deleteTimeEntry}
+            />
+          ))}
+        </section>
+
+        {/* Right: summary */}
+        <aside style={{
+          position: 'sticky', top: 0,
+          background: T.surface, border: `1px solid ${T.border}`, borderRadius: 6,
+          padding: 12,
+        }}>
+          <div style={{
+            display: 'flex', justifyContent: 'space-between', alignItems: 'center',
+            marginBottom: 8,
+          }}>
+            <div style={{ fontSize: 12, fontWeight: 600 }}>Summary</div>
+            <div style={{
+              display: 'flex', gap: 2, padding: 2,
+              background: T.surface2, border: `1px solid ${T.border}`, borderRadius: 4,
+            }}>
+              {['day', 'week', 'month'].map(p => (
+                <button key={p} onClick={() => setPeriod(p)} style={{
+                  padding: '2px 8px', fontSize: 10, fontFamily: FONT,
+                  background: period === p ? T.surface : 'transparent',
+                  color: period === p ? T.text : T.textMute,
+                  border: 'none', borderRadius: 3, cursor: 'pointer',
+                  fontWeight: period === p ? 500 : 400, textTransform: 'capitalize',
+                }}>{p}</button>
+              ))}
+            </div>
+          </div>
+
+          {!summary || summary.buckets.length === 0 ? (
+            <div style={{ fontSize: 11, color: T.textDim, padding: 12, textAlign: 'center' }}>
+              無資料
+            </div>
+          ) : (
+            <>
+              <OverallBlock overall={summary.overall} itemColor={itemColor} />
+              <div style={{
+                fontSize: 10, color: T.textDim, textTransform: 'uppercase',
+                letterSpacing: 0.5, fontWeight: 600, marginTop: 14, marginBottom: 6,
+              }}>
+                Per {period}
+              </div>
+              <div style={{ maxHeight: 360, overflow: 'auto', display: 'flex', flexDirection: 'column', gap: 10 }}>
+                {summary.buckets.map(b => (
+                  <BucketBlock key={b.key} bucket={b} period={period} itemColor={itemColor} />
+                ))}
+              </div>
+            </>
+          )}
+        </aside>
+      </div>
+    </div>
+  );
+}
+
+function QuickEntryForm({ knownItems, onSubmit }) {
+  const [item, setItem] = useState('');
+  const [hours, setHours] = useState('1');
+  const [date, setDate] = useState(todayIso());
+  const [note, setNote] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+
+  const canSubmit = item.trim() && parseFloat(hours) > 0 && date && !submitting;
+
+  const submit = async (e) => {
+    e?.preventDefault();
+    if (!canSubmit) return;
+    setSubmitting(true);
+    await onSubmit?.({
+      item: item.trim(),
+      hours: parseFloat(hours),
+      date,
+      note: note.trim() || null,
+    });
+    setSubmitting(false);
+    setItem('');
+    setNote('');
+    setHours('1');
+  };
+
+  return (
+    <form onSubmit={submit} style={{
+      display: 'grid',
+      gridTemplateColumns: '1fr 110px 150px auto',
+      gap: 6, padding: 10,
+      background: T.surface, border: `1px solid ${T.border}`, borderRadius: 6,
+    }}>
+      <input
+        type="text"
+        value={item}
+        onChange={(e) => setItem(e.target.value)}
+        placeholder="花時間在什麼上面？"
+        list="time-log-items"
+        disabled={submitting}
+        style={input}
+      />
+      <input
+        type="number"
+        min="0.25"
+        step="0.25"
+        value={hours}
+        onChange={(e) => setHours(e.target.value)}
+        disabled={submitting}
+        style={{ ...input, fontFamily: MONO }}
+        title="Hours (0.25 step)"
+      />
+      <input
+        type="date"
+        value={date}
+        onChange={(e) => setDate(e.target.value)}
+        disabled={submitting}
+        style={{ ...input, fontFamily: MONO }}
+      />
+      <Btn variant="primary" type="submit" icon="plus" disabled={!canSubmit}>Log</Btn>
+      <textarea
+        rows={1}
+        value={note}
+        onChange={(e) => setNote(e.target.value)}
+        placeholder="備註（可留空）"
+        disabled={submitting}
+        style={{
+          ...input, gridColumn: '1 / -1',
+          resize: 'vertical', minHeight: 28, fontFamily: FONT,
+        }}
+      />
+      <datalist id="time-log-items">
+        {knownItems.map(it => <option key={it} value={it} />)}
+      </datalist>
+    </form>
+  );
+}
+
+function EmptyState() {
+  return (
+    <div style={{
+      padding: 32, textAlign: 'center',
+      background: T.surface, border: `1px dashed ${T.border}`, borderRadius: 6,
+    }}>
+      <I d={ICON.clock} size={28} style={{ color: T.textFaint, marginBottom: 8 }} />
+      <div style={{ fontSize: 13, fontWeight: 500, marginBottom: 4 }}>還沒有任何紀錄</div>
+      <div style={{ fontSize: 11, color: T.textMute }}>
+        用上方表單記錄今天花時間做了什麼。自由文字，之後可以自動帶出。
+      </div>
+    </div>
+  );
+}
+
+function DateGroup({ group, itemColor, editingId, setEditingId, onUpdate, onDelete }) {
+  return (
+    <div style={{ marginBottom: 14 }}>
+      <div style={{
+        display: 'flex', justifyContent: 'space-between', alignItems: 'baseline',
+        padding: '4px 2px', fontSize: 11, color: T.textMute,
+        borderBottom: `1px solid ${T.divider}`, marginBottom: 6,
+      }}>
+        <span>
+          <span style={{ fontFamily: MONO, fontWeight: 600, color: T.text }}>{group.date}</span>
+          <span style={{ marginLeft: 6, color: T.textDim }}>{weekdayIso(group.date)}</span>
+        </span>
+        <span style={{ fontFamily: MONO, color: T.textMute }}>
+          {group.total.toFixed(2)}h total
+        </span>
+      </div>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+        {group.entries.map(e => (
+          <EntryRow
+            key={e.id}
+            entry={e}
+            color={itemColor.get(e.item)}
+            editing={editingId === e.id}
+            onStartEdit={() => setEditingId(e.id)}
+            onCancelEdit={() => setEditingId(null)}
+            onUpdate={onUpdate}
+            onDelete={onDelete}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function EntryRow({ entry, color, editing, onStartEdit, onCancelEdit, onUpdate, onDelete }) {
+  const [draft, setDraft] = useState({
+    item: entry.item, hours: String(entry.hours), date: entry.date, note: entry.note || '',
+  });
+
+  useEffect(() => {
+    setDraft({ item: entry.item, hours: String(entry.hours), date: entry.date, note: entry.note || '' });
+  }, [entry]);
+
+  const save = async () => {
+    const patch = {
+      item: draft.item.trim() || entry.item,
+      hours: parseFloat(draft.hours) || entry.hours,
+      date: draft.date || entry.date,
+      note: draft.note.trim() || null,
+    };
+    await onUpdate(entry.id, patch);
+    onCancelEdit();
+  };
+
+  if (editing) {
+    return (
+      <div style={{
+        padding: 8, background: T.irisSoft, border: `1px solid #D7DAFF`, borderRadius: 5,
+        display: 'grid', gridTemplateColumns: '1fr 80px 120px auto auto', gap: 6,
+      }}>
+        <input value={draft.item} onChange={(e) => setDraft({ ...draft, item: e.target.value })} style={input} />
+        <input type="number" min="0.25" step="0.25" value={draft.hours}
+          onChange={(e) => setDraft({ ...draft, hours: e.target.value })} style={{ ...input, fontFamily: MONO }} />
+        <input type="date" value={draft.date}
+          onChange={(e) => setDraft({ ...draft, date: e.target.value })} style={{ ...input, fontFamily: MONO }} />
+        <Btn variant="primary" onClick={save}>Save</Btn>
+        <Btn variant="ghost" onClick={onCancelEdit}>Cancel</Btn>
+        <input
+          value={draft.note}
+          onChange={(e) => setDraft({ ...draft, note: e.target.value })}
+          placeholder="Notes"
+          style={{ ...input, gridColumn: '1 / -1' }}
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div
+      style={{
+        display: 'grid',
+        gridTemplateColumns: '10px 1fr 70px auto',
+        gap: 8, alignItems: 'center', padding: '6px 8px',
+        background: T.surface, border: `1px solid ${T.border}`, borderRadius: 5,
+        fontSize: 12,
+      }}
+    >
+      <span style={{ width: 4, height: 18, background: color || T.textDim, borderRadius: 2 }} />
+      <div style={{ minWidth: 0 }}>
+        <div style={{ fontWeight: 500, color: T.text, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+          {entry.item}
+        </div>
+        {entry.note && (
+          <div style={{ fontSize: 11, color: T.textMute, marginTop: 2, wordBreak: 'break-word' }}>
+            {entry.note}
+          </div>
+        )}
+      </div>
+      <span style={{ fontFamily: MONO, color: T.textMute, textAlign: 'right' }}>
+        {entry.hours.toFixed(2)}h
+      </span>
+      <span style={{ display: 'flex', gap: 2 }}>
+        <button style={iconBtn} onClick={onStartEdit} title="Edit">
+          <I d={ICON.pencil} size={12} />
+        </button>
+        <button
+          style={iconBtn}
+          onClick={() => confirm('Delete this entry?') && onDelete(entry.id)}
+          title="Delete"
+        >
+          <I d={ICON.trash} size={12} />
+        </button>
+      </span>
+    </div>
+  );
+}
+
+function OverallBlock({ overall, itemColor }) {
+  return (
+    <div>
+      <div style={{
+        fontSize: 10, color: T.textDim, textTransform: 'uppercase',
+        letterSpacing: 0.5, fontWeight: 600, marginBottom: 4,
+      }}>
+        Overall · {overall.total.toFixed(2)}h
+      </div>
+      <StackedBar items={overall.items} itemColor={itemColor} />
+      <div style={{ marginTop: 6, display: 'flex', flexDirection: 'column', gap: 4 }}>
+        {overall.items.slice(0, 8).map(it => (
+          <LegendRow key={it.item} it={it} color={itemColor.get(it.item)} />
+        ))}
+        {overall.items.length > 8 && (
+          <div style={{ fontSize: 10, color: T.textDim }}>
+            +{overall.items.length - 8} more
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function BucketBlock({ bucket, period, itemColor }) {
+  return (
+    <div>
+      <div style={{
+        display: 'flex', justifyContent: 'space-between', alignItems: 'baseline',
+        fontSize: 11, marginBottom: 4,
+      }}>
+        <span style={{ fontFamily: MONO, color: T.text, fontWeight: 500 }}>
+          {period === 'month' ? bucket.key.slice(0, 7) : bucket.key}
+        </span>
+        <span style={{ fontFamily: MONO, color: T.textMute }}>{bucket.total.toFixed(2)}h</span>
+      </div>
+      <StackedBar items={bucket.items} itemColor={itemColor} thin />
+      <div style={{ marginTop: 4, display: 'flex', flexWrap: 'wrap', gap: 4 }}>
+        {bucket.items.slice(0, 4).map(it => (
+          <Badge key={it.item} tone="neutral" size="sm">
+            <span style={{
+              width: 6, height: 6, borderRadius: 6,
+              background: itemColor.get(it.item), display: 'inline-block', marginRight: 4,
+            }} />
+            {it.item} · {it.percent}%
+          </Badge>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function StackedBar({ items, itemColor, thin }) {
+  return (
+    <div style={{
+      height: thin ? 5 : 8, background: T.surface2,
+      borderRadius: 3, overflow: 'hidden', display: 'flex',
+    }}>
+      {items.map(it => (
+        <div
+          key={it.item}
+          title={`${it.item} · ${it.hours}h · ${it.percent}%`}
+          style={{ width: `${it.percent}%`, background: itemColor.get(it.item) || T.textDim }}
+        />
+      ))}
+    </div>
+  );
+}
+
+function LegendRow({ it, color }) {
+  return (
+    <div style={{
+      display: 'flex', alignItems: 'center', gap: 6,
+      fontSize: 11, color: T.textMute,
+    }}>
+      <span style={{ width: 8, height: 8, borderRadius: 8, background: color || T.textDim, flexShrink: 0 }} />
+      <span style={{
+        flex: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', color: T.text,
+      }}>{it.item}</span>
+      <span style={{ fontFamily: MONO, color: T.textMute }}>
+        {it.hours}h
+      </span>
+      <span style={{ fontFamily: MONO, color: T.textDim, minWidth: 40, textAlign: 'right' }}>
+        {it.percent}%
+      </span>
+    </div>
+  );
+}
+
+const input = {
+  padding: '6px 8px', fontSize: 12, fontFamily: FONT, color: T.text,
+  background: T.surface, border: `1px solid ${T.border}`, borderRadius: 4,
+  outline: 'none', minWidth: 0,
+};
+const iconBtn = {
+  width: 22, height: 22, border: 'none', background: 'transparent',
+  color: T.textDim, cursor: 'pointer', borderRadius: 3,
+  display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
+};

--- a/src/pages/TodosPage.jsx
+++ b/src/pages/TodosPage.jsx
@@ -1,0 +1,320 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { T, FONT } from '../design/tokens.js';
+import { Btn } from '../design/primitives.jsx';
+import { KanbanBoard } from '../components/todo/KanbanBoard.jsx';
+import { PRIO_ORDER } from '../components/todo/KanbanCard.jsx';
+import { TodoFormModal } from '../components/todo/TodoFormModal.jsx';
+
+export function TodosPage({ data, initialEditTodoId, onClearInitialEditTodoId }) {
+  const {
+    todos, statuses, allTasks, subProjects, today,
+    createTodo, updateTodo, deleteTodo,
+    createComment, updateComment, deleteComment,
+    createStatus, updateStatus, deleteStatus, reorderStatuses,
+  } = data;
+
+  const [modalTodo, setModalTodo] = useState(null); // current todo for editing; {} for new
+
+  // Honour an external request to open a specific todo (e.g. from Cmd+K).
+  useEffect(() => {
+    if (!initialEditTodoId) return;
+    const target = todos.find(t => t.id === initialEditTodoId);
+    if (target) setModalTodo(target);
+    onClearInitialEditTodoId?.();
+  }, [initialEditTodoId, todos, onClearInitialEditTodoId]);
+  const [filterAssignees, setFilterAssignees] = useState(new Set());
+  const [filterPriorities, setFilterPriorities] = useState(new Set());
+  const [filterTags, setFilterTags] = useState(new Set());
+  const [filterSubProjectId, setFilterSubProjectId] = useState('');
+  const [showFilters, setShowFilters] = useState(false);
+  const [hideDone, setHideDone] = useState(false);
+  const [sortBy, setSortBy] = useState('dueDate-asc');
+
+  const endStatusId = useMemo(() => statuses.find(s => s.isDefaultEnd)?.id, [statuses]);
+
+  const orderedStatuses = useMemo(
+    () => [...statuses].sort((a, b) => (a.sortOrder ?? 0) - (b.sortOrder ?? 0)),
+    [statuses]
+  );
+  const visibleStatuses = hideDone
+    ? orderedStatuses.filter(s => !s.isDefaultEnd)
+    : orderedStatuses;
+
+  const allTags = useMemo(() => {
+    const s = new Set();
+    todos.forEach(t => (t.tags || []).forEach(tag => s.add(tag)));
+    return Array.from(s).sort();
+  }, [todos]);
+  const allAssignees = useMemo(() => {
+    const s = new Set();
+    todos.forEach(t => { if (t.assignee) s.add(t.assignee); });
+    return Array.from(s).sort();
+  }, [todos]);
+
+  const overdueCount = useMemo(() => todos.reduce((n, t) => (
+    t.dueDate && t.dueDate < today && t.status !== endStatusId ? n + 1 : n
+  ), 0), [todos, today, endStatusId]);
+
+  const filteredTodos = useMemo(() => {
+    let list = todos;
+    if (filterAssignees.size > 0) list = list.filter(t => filterAssignees.has(t.assignee || ''));
+    if (filterPriorities.size > 0) list = list.filter(t => filterPriorities.has(t.priority));
+    if (filterTags.size > 0) list = list.filter(t => (t.tags || []).some(tag => filterTags.has(tag)));
+    if (filterSubProjectId) list = list.filter(t => (t.subProjectId || '') === filterSubProjectId);
+    const sorted = [...list];
+    if (sortBy === 'dueDate-asc') sorted.sort((a, b) => (a.dueDate || '9999') < (b.dueDate || '9999') ? -1 : 1);
+    else if (sortBy === 'dueDate-desc') sorted.sort((a, b) => (b.dueDate || '') < (a.dueDate || '') ? -1 : 1);
+    else if (sortBy === 'priority') sorted.sort((a, b) => (PRIO_ORDER[a.priority] ?? 9) - (PRIO_ORDER[b.priority] ?? 9));
+    else sorted.sort((a, b) => (a.sortOrder ?? 0) - (b.sortOrder ?? 0));
+    return sorted;
+  }, [todos, filterAssignees, filterPriorities, filterTags, filterSubProjectId, sortBy]);
+
+  const taskNameById = useMemo(() => {
+    const map = new Map();
+    allTasks.forEach(t => map.set(t.id, t.name));
+    return map;
+  }, [allTasks]);
+  const subProjectNameById = useMemo(() => {
+    const map = new Map();
+    subProjects.forEach(s => map.set(s.id, s.name));
+    return map;
+  }, [subProjects]);
+
+  const handleMove = (todoId, statusId) => updateTodo(todoId, { status: statusId });
+
+  const handleSave = async (payload) => {
+    if (payload.id) {
+      const { id, ...patch } = payload;
+      await updateTodo(id, patch);
+    } else {
+      await createTodo(payload);
+    }
+    setModalTodo(null);
+  };
+  const handleDelete = async (id) => {
+    await deleteTodo(id);
+    setModalTodo(null);
+  };
+
+  // Column management
+  const handleAddColumn = async () => {
+    const maxOrder = orderedStatuses.reduce((m, s) => Math.max(m, s.sortOrder ?? 0), -1);
+    await createStatus({ name: '新狀態', sortOrder: maxOrder + 1 });
+  };
+  const handleRenameColumn = (id, name) => updateStatus(id, { name });
+  const handleDeleteColumn = (id, migrateTo) => deleteStatus(id, migrateTo);
+  const handleSetDefaultStart = async (id) => {
+    await updateStatus(id, { isDefaultStart: true });
+  };
+  const handleSetDefaultEnd = async (id) => {
+    await updateStatus(id, { isDefaultEnd: true });
+  };
+
+  const openCreate = () => setModalTodo({});
+
+  // live refresh of modal todo from store
+  const liveModalTodo = modalTodo?.id
+    ? (todos.find(t => t.id === modalTodo.id) || modalTodo)
+    : modalTodo;
+
+  const totalFilterCount = filterAssignees.size + filterPriorities.size + filterTags.size + (filterSubProjectId ? 1 : 0);
+
+  return (
+    <div style={{
+      padding: 16, height: '100%', background: T.bg,
+      display: 'flex', flexDirection: 'column', overflow: 'hidden',
+    }}>
+      <div style={{
+        display: 'flex', alignItems: 'baseline', justifyContent: 'space-between',
+        marginBottom: 12, flexWrap: 'wrap', gap: 10,
+      }}>
+        <div>
+          <h1 style={{ fontSize: 20, fontWeight: 600, letterSpacing: -0.4, margin: 0 }}>Todos</h1>
+          <div style={{ fontSize: 12, color: T.textMute, marginTop: 2 }}>
+            {todos.length} cards across {orderedStatuses.length} columns
+            {overdueCount > 0 && (
+              <> · <span style={{ color: T.danger, fontWeight: 500 }}>{overdueCount} overdue</span></>
+            )}
+          </div>
+        </div>
+
+        <div style={{ display: 'flex', gap: 6, alignItems: 'center', flexWrap: 'wrap' }}>
+          <Btn
+            variant={showFilters ? 'subtle' : 'ghost'}
+            icon="filter"
+            onClick={() => setShowFilters(v => !v)}
+          >
+            {totalFilterCount > 0 ? `${totalFilterCount} filter${totalFilterCount > 1 ? 's' : ''}` : 'Filter'}
+          </Btn>
+          <select value={sortBy} onChange={(e) => setSortBy(e.target.value)} style={selectStyle}>
+            <option value="dueDate-asc">Sort · due ↑</option>
+            <option value="dueDate-desc">Sort · due ↓</option>
+            <option value="priority">Sort · priority</option>
+            <option value="manual">Sort · manual</option>
+          </select>
+          <Btn variant={hideDone ? 'subtle' : 'ghost'} icon="eye" onClick={() => setHideDone(v => !v)}>
+            {hideDone ? 'Show done' : 'Hide done'}
+          </Btn>
+          <div style={{ width: 1, height: 16, background: T.border, margin: '0 4px' }} />
+          <Btn variant="primary" icon="plus" onClick={openCreate}>Add todo</Btn>
+        </div>
+      </div>
+
+      {showFilters && (
+        <FilterPanel
+          allAssignees={allAssignees}
+          allTags={allTags}
+          subProjects={subProjects}
+          filterAssignees={filterAssignees}
+          filterPriorities={filterPriorities}
+          filterTags={filterTags}
+          filterSubProjectId={filterSubProjectId}
+          onToggleAssignee={(v) => setFilterAssignees(toggleInSet(v))}
+          onTogglePriority={(v) => setFilterPriorities(toggleInSet(v))}
+          onToggleTag={(v) => setFilterTags(toggleInSet(v))}
+          onSetSubProject={setFilterSubProjectId}
+          onClearAll={() => {
+            setFilterAssignees(new Set());
+            setFilterPriorities(new Set());
+            setFilterTags(new Set());
+            setFilterSubProjectId('');
+          }}
+        />
+      )}
+
+      <KanbanBoard
+        statuses={visibleStatuses}
+        todos={filteredTodos}
+        today={today}
+        taskNameById={taskNameById}
+        subProjectNameById={subProjectNameById}
+        onMoveTodo={handleMove}
+        onCardClick={(t) => setModalTodo(t)}
+        onRenameStatus={handleRenameColumn}
+        onAddStatus={handleAddColumn}
+        onDeleteStatus={handleDeleteColumn}
+        onReorderStatuses={reorderStatuses}
+        onSetDefaultStart={handleSetDefaultStart}
+        onSetDefaultEnd={handleSetDefaultEnd}
+      />
+
+      {modalTodo && (
+        <TodoFormModal
+          todo={liveModalTodo?.id ? liveModalTodo : null}
+          statuses={orderedStatuses}
+          allTasks={allTasks}
+          subProjects={subProjects}
+          allTags={allTags}
+          allAssignees={allAssignees}
+          onSave={handleSave}
+          onDelete={handleDelete}
+          onClose={() => setModalTodo(null)}
+          onCreateComment={createComment}
+          onUpdateComment={updateComment}
+          onDeleteComment={deleteComment}
+        />
+      )}
+    </div>
+  );
+}
+
+function toggleInSet(value) {
+  return (prev) => {
+    const next = new Set(prev);
+    if (next.has(value)) next.delete(value);
+    else next.add(value);
+    return next;
+  };
+}
+
+function FilterPanel({
+  allAssignees, allTags, subProjects,
+  filterAssignees, filterPriorities, filterTags, filterSubProjectId,
+  onToggleAssignee, onTogglePriority, onToggleTag, onSetSubProject, onClearAll,
+}) {
+  const anyActive = filterAssignees.size + filterPriorities.size + filterTags.size + (filterSubProjectId ? 1 : 0) > 0;
+  return (
+    <div style={{
+      marginBottom: 12, padding: 12, background: T.surface, border: `1px solid ${T.border}`,
+      borderRadius: 6, display: 'flex', flexDirection: 'column', gap: 10,
+    }}>
+      <FilterSection label="Assignee" items={allAssignees} isActive={(v) => filterAssignees.has(v)} onToggle={onToggleAssignee} />
+      <FilterSection
+        label="Priority"
+        items={[['high', 'High'], ['medium', 'Medium'], ['low', 'Low']]}
+        isActive={(v) => filterPriorities.has(v)}
+        onToggle={onTogglePriority}
+      />
+      {allTags.length > 0 && (
+        <FilterSection label="Tags" items={allTags.map(t => [t, `#${t}`])} isActive={(v) => filterTags.has(v)} onToggle={onToggleTag} />
+      )}
+      {subProjects.length > 0 && (
+        <div>
+          <div style={sectionLabel}>Sub-project</div>
+          <div style={{ display: 'flex', flexWrap: 'wrap', gap: 4 }}>
+            <ChipButton active={!filterSubProjectId} onClick={() => onSetSubProject('')}>Any</ChipButton>
+            {subProjects.map(sp => (
+              <ChipButton key={sp.id} active={filterSubProjectId === sp.id} onClick={() => onSetSubProject(sp.id)}>
+                {sp.name}
+              </ChipButton>
+            ))}
+          </div>
+        </div>
+      )}
+      {anyActive && (
+        <div style={{ alignSelf: 'flex-end' }}>
+          <Btn variant="ghost" onClick={onClearAll}>Clear all</Btn>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function FilterSection({ label, items, isActive, onToggle }) {
+  const normalized = items.map(it => Array.isArray(it) ? it : [it, it]);
+  return (
+    <div>
+      <div style={sectionLabel}>{label}</div>
+      <div style={{ display: 'flex', flexWrap: 'wrap', gap: 4 }}>
+        {normalized.map(([value, label]) => (
+          <ChipButton key={value} active={isActive(value)} onClick={() => onToggle(value)}>
+            {label}
+          </ChipButton>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function ChipButton({ active, onClick, children }) {
+  return (
+    <button
+      onClick={onClick}
+      style={{
+        padding: '3px 8px', fontSize: 11, fontFamily: FONT,
+        background: active ? T.irisSoft : T.surface,
+        color: active ? T.iris : T.textMute,
+        border: `1px solid ${active ? '#D7DAFF' : T.border}`,
+        borderRadius: 3, cursor: 'pointer',
+        fontWeight: active ? 500 : 400,
+      }}
+    >
+      {children}
+    </button>
+  );
+}
+
+const sectionLabel = {
+  fontSize: 10, color: T.textDim, textTransform: 'uppercase',
+  letterSpacing: 0.5, fontWeight: 600, marginBottom: 4,
+};
+
+const selectStyle = {
+  height: 26, padding: '0 22px 0 8px', fontFamily: FONT, fontSize: 11,
+  color: T.text, background: T.surface, border: `1px solid ${T.border}`,
+  borderRadius: 4, cursor: 'pointer', appearance: 'none',
+  backgroundImage: `linear-gradient(45deg, transparent 50%, ${T.textDim} 50%), linear-gradient(135deg, ${T.textDim} 50%, transparent 50%)`,
+  backgroundPosition: `right 9px top 11px, right 5px top 11px`,
+  backgroundSize: '4px 4px, 4px 4px',
+  backgroundRepeat: 'no-repeat',
+};

--- a/src/pages/TodosPage.jsx
+++ b/src/pages/TodosPage.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { T, FONT } from '../design/tokens.js';
 import { Btn } from '../design/primitives.jsx';
 import { KanbanBoard } from '../components/todo/KanbanBoard.jsx';
@@ -14,14 +14,17 @@ export function TodosPage({ data, initialEditTodoId, onClearInitialEditTodoId })
   } = data;
 
   const [modalTodo, setModalTodo] = useState(null); // current todo for editing; {} for new
+  const [lastInitialEditTodoId, setLastInitialEditTodoId] = useState(null);
 
-  // Honour an external request to open a specific todo (e.g. from Cmd+K).
-  useEffect(() => {
-    if (!initialEditTodoId) return;
+  // Honour an external request to open a specific todo (e.g. from Cmd+K)
+  // via a render-time prop sync (avoids setState-in-effect).
+  if (initialEditTodoId && initialEditTodoId !== lastInitialEditTodoId) {
+    setLastInitialEditTodoId(initialEditTodoId);
     const target = todos.find(t => t.id === initialEditTodoId);
     if (target) setModalTodo(target);
     onClearInitialEditTodoId?.();
-  }, [initialEditTodoId, todos, onClearInitialEditTodoId]);
+  }
+
   const [filterAssignees, setFilterAssignees] = useState(new Set());
   const [filterPriorities, setFilterPriorities] = useState(new Set());
   const [filterTags, setFilterTags] = useState(new Set());

--- a/src/test-setup.js
+++ b/src/test-setup.js
@@ -1,1 +1,6 @@
 import '@testing-library/jest-dom/vitest';
+
+// JSDOM doesn't implement layout APIs we use in some components.
+if (typeof Element !== 'undefined' && !Element.prototype.scrollIntoView) {
+  Element.prototype.scrollIntoView = () => {};
+}


### PR DESCRIPTION
## Summary

- Full "Next" UI redesign (Linear/Height-inspired) shipped behind a `Shift+U` toggle pill; Legacy UI remains default for A/B comparison.
- New Time log feature: per-user work-hours tracking with day/week/month summary and percent breakdown.
- Backend unified `/api/activity` feed (logs + todo comments + sub-project events) and author tracking on logs / todo_comments.

## What's new

**Next UI pages** (behind Shift+U / `?ui=next`): Burnup dashboard (KPI + SVG chart + Activity rail + task table), Gantt with lane-packing + drag/resize + day/week/month zoom, Todo kanban with full CRUD + column management + multi-select filters, Merged view, Sub-projects with Activity composer, Cmd+K SearchModal (incomplete todos ranked first), TaskDetailModal, LoginPage with bootstrap mode, EmptyProject state.

**Time log** (`#timelog`): free-text item + 0.25h precision + default-today; summary panel toggles day/week/month with stacked bar + percent legend; per-user isolation.

**Backend additions**: `/api/activity`, `/api/time-entries` + `/summary`, author_id wired into logs and todo_comments INSERT + author display name returned via JOIN.

## Tests

- Backend pytest: **99 passing** (+22 new)
- Frontend vitest: **120 passing** (+79 new) — pure logic (weekCode, formatTime timezone regression, packLanes, burnupMath), component interaction (ProgressCell, SearchModal, KanbanBoard)
- Playwright e2e: **34 passing** (+3 new) — UI toggle, `?ui=` override, Time log happy path

## Test plan

- [ ] Hard reload; confirm Legacy UI loads by default
- [ ] Shift+U → Next shell with sidebar; Shift+U again → back to Legacy
- [ ] Burnup: KPI numbers, chart hover tooltip, progress cell drag/type, label checkbox toggles chart annotation
- [ ] Gantt: lane-packing renders, drag a bar → dates update; same-assignee overlap uses warn/danger stripes
- [ ] Todos: card click opens form; drag across columns persists; add/rename/delete/reorder columns; filter panel chips toggle
- [ ] Merged: pick 2+ projects; aggregated burnup + contribution bars render
- [ ] Sub-projects: create one; post waiting/decision/note events; Resolve waiting
- [ ] Time log: add entry → list + Day/Week/Month summary update; edit/delete works; second user can't see your entries
- [ ] Cmd+K: incomplete todos appear before tasks/done todos; Enter opens TaskDetailModal or TodoFormModal
- [ ] Session expiry: while authenticated in Next, let token expire → LoginPage appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)